### PR TITLE
fix: deployment skipped when only environment variables are changed

### DIFF
--- a/lambda/trigger-codebuild/index.ts
+++ b/lambda/trigger-codebuild/index.ts
@@ -1,5 +1,6 @@
 import { BatchGetBuildsCommand, CodeBuildClient, StartBuildCommand } from '@aws-sdk/client-codebuild';
 import type { ResourceProperties } from '../../src/types';
+import Crypto from 'crypto';
 
 const cb = new CodeBuildClient({});
 
@@ -46,7 +47,8 @@ export const handler = async (event: Event, context: any) => {
               },
               {
                 name: 'destinationObjectKey',
-                value: props.destinationObjectKey,
+                // This should be random to always trigger a BucketDeployment update process
+                value: `${Crypto.randomBytes(16).toString('hex')}.zip`,
               },
               {
                 name: 'workingDirectory',

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,6 @@ export type NodejsBuildResourceProps = {
   }[];
   environment?: { [key: string]: string };
   destinationBucketName: string;
-  destinationObjectKey: string;
   workingDirectory: string;
   outputSourceDirectory: string;
   buildCommands: string[];

--- a/test/nodejs-build.integ.snapshot/NodejsBuildIntegTest.template.json
+++ b/test/nodejs-build.integ.snapshot/NodejsBuildIntegTest.template.json
@@ -384,7 +384,7 @@
      ]
     },
     "Source": {
-     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"install\": {\n      \"runtime-versions\": {\n        \"nodejs\": 20\n      }\n    },\n    \"build\": {\n      \"commands\": [\n        \"current_dir=$(pwd)\",\n        \"\\necho \\\"$input\\\"\\nfor obj in $(echo \\\"$input\\\" | jq -r '.[] | @base64'); do\\n  decoded=$(echo \\\"$obj\\\" | base64 --decode)\\n  assetUrl=$(echo \\\"$decoded\\\" | jq -r '.assetUrl')\\n  extractPath=$(echo \\\"$decoded\\\" | jq -r '.extractPath')\\n  commands=$(echo \\\"$decoded\\\" | jq -r '.commands')\\n\\n  # Download the zip file\\n  aws s3 cp \\\"$assetUrl\\\" temp.zip\\n\\n  # Extract the zip file to the extractPath directory\\n  mkdir -p \\\"$extractPath\\\"\\n  unzip temp.zip -d \\\"$extractPath\\\"\\n\\n  # Remove the zip file\\n  rm temp.zip\\n\\n  # Run the specified commands in the extractPath directory\\n  cd \\\"$extractPath\\\"\\n  ls -la\\n  eval \\\"$commands\\\"\\n  cd \\\"$current_dir\\\"\\n  ls -la\\ndone\\n              \",\n        \"ls -la\",\n        \"cd \\\"$workingDirectory\\\"\",\n        \"eval \\\"$buildCommands\\\"\",\n        \"ls -la\",\n        \"cd \\\"$current_dir\\\"\",\n        \"cd \\\"$outputSourceDirectory\\\"\",\n        \"zip -r output.zip ./\",\n        \"aws s3 cp output.zip \\\"s3://$destinationBucketName/$destinationObjectKey\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"echo Build completed on `date`\",\n        \"\\nSTATUS='SUCCESS'\\nif [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ] # Test if the build is failing\\nthen\\nSTATUS='FAILED'\\nREASON=\\\"NodejsBuild failed. See CloudWatch Log stream for the detailed reason: \\nhttps://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#logsV2:log-groups/log-group/\\\\$252Faws\\\\$252Fcodebuild\\\\$252F$projectName/log-events/$CODEBUILD_LOG_PATH\\\"\\nfi\\ncat <<EOF > payload.json\\n{\\n  \\\"StackId\\\": \\\"$stackId\\\",\\n  \\\"RequestId\\\": \\\"$requestId\\\",\\n  \\\"LogicalResourceId\\\":\\\"$logicalResourceId\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$destinationObjectKey\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"$REASON\\\"\\n}\\nEOF\\ncurl -vv -i -X PUT -H 'Content-Type:' -d \\\"@payload.json\\\" \\\"$responseURL\\\"\\n              \"\n      ]\n    }\n  }\n}",
+     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"install\": {\n      \"runtime-versions\": {\n        \"nodejs\": 20\n      }\n    },\n    \"build\": {\n      \"commands\": [\n        \"current_dir=$(pwd)\",\n        \"\\necho \\\"$input\\\"\\nfor obj in $(echo \\\"$input\\\" | jq -r '.[] | @base64'); do\\n  decoded=$(echo \\\"$obj\\\" | base64 --decode)\\n  assetUrl=$(echo \\\"$decoded\\\" | jq -r '.assetUrl')\\n  extractPath=$(echo \\\"$decoded\\\" | jq -r '.extractPath')\\n  commands=$(echo \\\"$decoded\\\" | jq -r '.commands')\\n\\n  # Download the zip file\\n  aws s3 cp \\\"$assetUrl\\\" temp.zip\\n\\n  # Extract the zip file to the extractPath directory\\n  mkdir -p \\\"$extractPath\\\"\\n  unzip temp.zip -d \\\"$extractPath\\\"\\n\\n  # Remove the zip file\\n  rm temp.zip\\n\\n  # Run the specified commands in the extractPath directory\\n  cd \\\"$extractPath\\\"\\n  ls -la\\n  eval \\\"$commands\\\"\\n  cd \\\"$current_dir\\\"\\n  ls -la\\ndone\\n              \",\n        \"ls -la\",\n        \"cd \\\"$workingDirectory\\\"\",\n        \"eval \\\"$buildCommands\\\"\",\n        \"ls -la\",\n        \"cd \\\"$current_dir\\\"\",\n        \"cd \\\"$outputSourceDirectory\\\"\",\n        \"zip -r output.zip ./\",\n        \"aws s3 cp output.zip \\\"s3://$destinationBucketName/$destinationObjectKey\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"echo Build completed on `date`\",\n        \"\\nSTATUS='SUCCESS'\\nif [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ] # Test if the build is failing\\nthen\\nSTATUS='FAILED'\\nREASON=\\\"NodejsBuild failed. See CloudWatch Log stream for the detailed reason: \\nhttps://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#logsV2:log-groups/log-group/\\\\$252Faws\\\\$252Fcodebuild\\\\$252F$projectName/log-events/$CODEBUILD_LOG_PATH\\\"\\nfi\\ncat <<EOF > payload.json\\n{\\n  \\\"StackId\\\": \\\"$stackId\\\",\\n  \\\"RequestId\\\": \\\"$requestId\\\",\\n  \\\"LogicalResourceId\\\":\\\"$logicalResourceId\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$logicalResourceId\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"$REASON\\\",\\n  \\\"Data\\\": {\\n    \\\"destinationObjectKey\\\": \\\"$destinationObjectKey\\\"\\n  }\\n}\\nEOF\\ncurl -v -i -X PUT -H 'Content-Type:' -d \\\"@payload.json\\\" \\\"$responseURL\\\"\\n              \"\n      ]\n    }\n  }\n}",
      "Type": "NO_SOURCE"
     },
     "Cache": {
@@ -447,7 +447,6 @@
     "destinationBucketName": {
      "Ref": "AssetParameters72f05c779a8bc73c6ec86f6eafc720508792e7526696d3ae45a7fddcfc473c9dS3Bucket7BF37945"
     },
-    "destinationObjectKey": "4f254f7921b3e0c451f0345408d704c9.zip",
     "workingDirectory": "example-app",
     "outputSourceDirectory": "example-app/dist",
     "environment": {
@@ -528,7 +527,12 @@
      }
     ],
     "SourceObjectKeys": [
-     "4f254f7921b3e0c451f0345408d704c9.zip"
+     {
+      "Fn::GetAtt": [
+       "ExampleBuild61F1D79B",
+       "destinationObjectKey"
+      ]
+     }
     ],
     "DestinationBucketName": {
      "Ref": "Destination920A3C57"
@@ -604,7 +608,7 @@
    "Properties": {
     "Code": {
      "S3Bucket": {
-      "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8"
+      "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97"
      },
      "S3Key": {
       "Fn::Join": [
@@ -617,7 +621,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+             "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
             }
            ]
           }
@@ -630,7 +634,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+             "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
             }
            ]
           }
@@ -855,17 +859,17 @@
    "Type": "String",
    "Description": "Artifact hash for asset \"e57c1acaa363d7d2b81736776007a7091bc73dff4aeb8135627c4511a51e7dca\""
   },
-  "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8": {
+  "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97": {
    "Type": "String",
-   "Description": "S3 bucket for asset \"b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363\""
+   "Description": "S3 bucket for asset \"16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f\""
   },
-  "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034": {
+  "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D": {
    "Type": "String",
-   "Description": "S3 key for asset version \"b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363\""
+   "Description": "S3 key for asset version \"16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f\""
   },
-  "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363ArtifactHash63F36728": {
+  "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fArtifactHash5D107D4A": {
    "Type": "String",
-   "Description": "Artifact hash for asset \"b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363\""
+   "Description": "Artifact hash for asset \"16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f\""
   },
   "AssetParameters72f05c779a8bc73c6ec86f6eafc720508792e7526696d3ae45a7fddcfc473c9dS3Bucket7BF37945": {
    "Type": "String",

--- a/test/nodejs-build.integ.snapshot/asset.16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/index.js
+++ b/test/nodejs-build.integ.snapshot/asset.16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/index.js
@@ -1,6 +1,8 @@
+var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __export = (target, all) => {
   for (var name in all)
@@ -14,6 +16,7 @@ var __copyProps = (to, from, except, desc) => {
   }
   return to;
 };
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target, mod));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // index.ts
@@ -23,6 +26,7 @@ __export(trigger_codebuild_exports, {
 });
 module.exports = __toCommonJS(trigger_codebuild_exports);
 var import_client_codebuild = require("@aws-sdk/client-codebuild");
+var import_crypto = __toESM(require("crypto"));
 var cb = new import_client_codebuild.CodeBuildClient({});
 var handler = async (event, context) => {
   console.log(JSON.stringify(event));
@@ -53,7 +57,7 @@ var handler = async (event, context) => {
               },
               {
                 name: "destinationObjectKey",
-                value: props.destinationObjectKey
+                value: `${import_crypto.default.randomBytes(16).toString("hex")}.zip`
               },
               {
                 name: "workingDirectory",

--- a/test/nodejs-build.integ.snapshot/manifest.json
+++ b/test/nodejs-build.integ.snapshot/manifest.json
@@ -31,13 +31,13 @@
           {
             "type": "aws:cdk:asset",
             "data": {
-              "path": "asset.b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
-              "id": "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
+              "path": "asset.16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
+              "id": "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
               "packaging": "zip",
-              "sourceHash": "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
-              "s3BucketParameter": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8",
-              "s3KeyParameter": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034",
-              "artifactHashParameter": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363ArtifactHash63F36728"
+              "sourceHash": "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
+              "s3BucketParameter": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97",
+              "s3KeyParameter": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D",
+              "artifactHashParameter": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fArtifactHash5D107D4A"
             }
           },
           {
@@ -125,22 +125,22 @@
             "data": "AssetParameterse57c1acaa363d7d2b81736776007a7091bc73dff4aeb8135627c4511a51e7dcaArtifactHashAC8BF1CD"
           }
         ],
-        "/NodejsBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3Bucket": [
+        "/NodejsBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3Bucket": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8"
+            "data": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97"
           }
         ],
-        "/NodejsBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3VersionKey": [
+        "/NodejsBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3VersionKey": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+            "data": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
           }
         ],
-        "/NodejsBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/ArtifactHash": [
+        "/NodejsBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/ArtifactHash": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363ArtifactHash63F36728"
+            "data": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fArtifactHash5D107D4A"
           }
         ],
         "/NodejsBuildIntegTest/AssetParameters/72f05c779a8bc73c6ec86f6eafc720508792e7526696d3ae45a7fddcfc473c9d/S3Bucket": [

--- a/test/nodejs-build.integ.snapshot/tree.json
+++ b/test/nodejs-build.integ.snapshot/tree.json
@@ -223,13 +223,13 @@
                   "version": "10.0.5"
                 }
               },
-              "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363": {
-                "id": "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
-                "path": "NodejsBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
+              "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f": {
+                "id": "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
+                "path": "NodejsBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
                 "children": {
                   "S3Bucket": {
                     "id": "S3Bucket",
-                    "path": "NodejsBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3Bucket",
+                    "path": "NodejsBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3Bucket",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -237,7 +237,7 @@
                   },
                   "S3VersionKey": {
                     "id": "S3VersionKey",
-                    "path": "NodejsBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3VersionKey",
+                    "path": "NodejsBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3VersionKey",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -245,7 +245,7 @@
                   },
                   "ArtifactHash": {
                     "id": "ArtifactHash",
-                    "path": "NodejsBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/ArtifactHash",
+                    "path": "NodejsBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/ArtifactHash",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -613,7 +613,7 @@
                         },
                         "source": {
                           "type": "NO_SOURCE",
-                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"install\": {\n      \"runtime-versions\": {\n        \"nodejs\": 20\n      }\n    },\n    \"build\": {\n      \"commands\": [\n        \"current_dir=$(pwd)\",\n        \"\\necho \\\"$input\\\"\\nfor obj in $(echo \\\"$input\\\" | jq -r '.[] | @base64'); do\\n  decoded=$(echo \\\"$obj\\\" | base64 --decode)\\n  assetUrl=$(echo \\\"$decoded\\\" | jq -r '.assetUrl')\\n  extractPath=$(echo \\\"$decoded\\\" | jq -r '.extractPath')\\n  commands=$(echo \\\"$decoded\\\" | jq -r '.commands')\\n\\n  # Download the zip file\\n  aws s3 cp \\\"$assetUrl\\\" temp.zip\\n\\n  # Extract the zip file to the extractPath directory\\n  mkdir -p \\\"$extractPath\\\"\\n  unzip temp.zip -d \\\"$extractPath\\\"\\n\\n  # Remove the zip file\\n  rm temp.zip\\n\\n  # Run the specified commands in the extractPath directory\\n  cd \\\"$extractPath\\\"\\n  ls -la\\n  eval \\\"$commands\\\"\\n  cd \\\"$current_dir\\\"\\n  ls -la\\ndone\\n              \",\n        \"ls -la\",\n        \"cd \\\"$workingDirectory\\\"\",\n        \"eval \\\"$buildCommands\\\"\",\n        \"ls -la\",\n        \"cd \\\"$current_dir\\\"\",\n        \"cd \\\"$outputSourceDirectory\\\"\",\n        \"zip -r output.zip ./\",\n        \"aws s3 cp output.zip \\\"s3://$destinationBucketName/$destinationObjectKey\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"echo Build completed on `date`\",\n        \"\\nSTATUS='SUCCESS'\\nif [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ] # Test if the build is failing\\nthen\\nSTATUS='FAILED'\\nREASON=\\\"NodejsBuild failed. See CloudWatch Log stream for the detailed reason: \\nhttps://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#logsV2:log-groups/log-group/\\\\$252Faws\\\\$252Fcodebuild\\\\$252F$projectName/log-events/$CODEBUILD_LOG_PATH\\\"\\nfi\\ncat <<EOF > payload.json\\n{\\n  \\\"StackId\\\": \\\"$stackId\\\",\\n  \\\"RequestId\\\": \\\"$requestId\\\",\\n  \\\"LogicalResourceId\\\":\\\"$logicalResourceId\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$destinationObjectKey\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"$REASON\\\"\\n}\\nEOF\\ncurl -vv -i -X PUT -H 'Content-Type:' -d \\\"@payload.json\\\" \\\"$responseURL\\\"\\n              \"\n      ]\n    }\n  }\n}"
+                          "buildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"install\": {\n      \"runtime-versions\": {\n        \"nodejs\": 20\n      }\n    },\n    \"build\": {\n      \"commands\": [\n        \"current_dir=$(pwd)\",\n        \"\\necho \\\"$input\\\"\\nfor obj in $(echo \\\"$input\\\" | jq -r '.[] | @base64'); do\\n  decoded=$(echo \\\"$obj\\\" | base64 --decode)\\n  assetUrl=$(echo \\\"$decoded\\\" | jq -r '.assetUrl')\\n  extractPath=$(echo \\\"$decoded\\\" | jq -r '.extractPath')\\n  commands=$(echo \\\"$decoded\\\" | jq -r '.commands')\\n\\n  # Download the zip file\\n  aws s3 cp \\\"$assetUrl\\\" temp.zip\\n\\n  # Extract the zip file to the extractPath directory\\n  mkdir -p \\\"$extractPath\\\"\\n  unzip temp.zip -d \\\"$extractPath\\\"\\n\\n  # Remove the zip file\\n  rm temp.zip\\n\\n  # Run the specified commands in the extractPath directory\\n  cd \\\"$extractPath\\\"\\n  ls -la\\n  eval \\\"$commands\\\"\\n  cd \\\"$current_dir\\\"\\n  ls -la\\ndone\\n              \",\n        \"ls -la\",\n        \"cd \\\"$workingDirectory\\\"\",\n        \"eval \\\"$buildCommands\\\"\",\n        \"ls -la\",\n        \"cd \\\"$current_dir\\\"\",\n        \"cd \\\"$outputSourceDirectory\\\"\",\n        \"zip -r output.zip ./\",\n        \"aws s3 cp output.zip \\\"s3://$destinationBucketName/$destinationObjectKey\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"echo Build completed on `date`\",\n        \"\\nSTATUS='SUCCESS'\\nif [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ] # Test if the build is failing\\nthen\\nSTATUS='FAILED'\\nREASON=\\\"NodejsBuild failed. See CloudWatch Log stream for the detailed reason: \\nhttps://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#logsV2:log-groups/log-group/\\\\$252Faws\\\\$252Fcodebuild\\\\$252F$projectName/log-events/$CODEBUILD_LOG_PATH\\\"\\nfi\\ncat <<EOF > payload.json\\n{\\n  \\\"StackId\\\": \\\"$stackId\\\",\\n  \\\"RequestId\\\": \\\"$requestId\\\",\\n  \\\"LogicalResourceId\\\":\\\"$logicalResourceId\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$logicalResourceId\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"$REASON\\\",\\n  \\\"Data\\\": {\\n    \\\"destinationObjectKey\\\": \\\"$destinationObjectKey\\\"\\n  }\\n}\\nEOF\\ncurl -v -i -X PUT -H 'Content-Type:' -d \\\"@payload.json\\\" \\\"$responseURL\\\"\\n              \"\n      ]\n    }\n  }\n}"
                         },
                         "cache": {
                           "type": "NO_CACHE"
@@ -937,7 +937,7 @@
                   "aws:cdk:cloudformation:props": {
                     "code": {
                       "s3Bucket": {
-                        "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8"
+                        "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97"
                       },
                       "s3Key": {
                         "Fn::Join": [
@@ -950,7 +950,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+                                      "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
                                     }
                                   ]
                                 }
@@ -963,7 +963,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+                                      "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
                                     }
                                   ]
                                 }

--- a/test/soci-index-build.integ.snapshot/SociIndexBuildIntegTest.template.json
+++ b/test/soci-index-build.integ.snapshot/SociIndexBuildIntegTest.template.json
@@ -81,7 +81,7 @@
    "Properties": {
     "Code": {
      "S3Bucket": {
-      "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8"
+      "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97"
      },
      "S3Key": {
       "Fn::Join": [
@@ -94,7 +94,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+             "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
             }
            ]
           }
@@ -107,7 +107,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+             "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
             }
            ]
           }
@@ -344,17 +344,17 @@
   }
  },
  "Parameters": {
-  "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8": {
+  "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97": {
    "Type": "String",
-   "Description": "S3 bucket for asset \"b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363\""
+   "Description": "S3 bucket for asset \"16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f\""
   },
-  "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034": {
+  "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D": {
    "Type": "String",
-   "Description": "S3 key for asset version \"b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363\""
+   "Description": "S3 key for asset version \"16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f\""
   },
-  "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363ArtifactHash63F36728": {
+  "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fArtifactHash5D107D4A": {
    "Type": "String",
-   "Description": "Artifact hash for asset \"b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363\""
+   "Description": "Artifact hash for asset \"16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f\""
   }
  }
 }

--- a/test/soci-index-build.integ.snapshot/asset.16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/index.js
+++ b/test/soci-index-build.integ.snapshot/asset.16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/index.js
@@ -1,6 +1,8 @@
+var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
 var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
 var __export = (target, all) => {
   for (var name in all)
@@ -14,6 +16,7 @@ var __copyProps = (to, from, except, desc) => {
   }
   return to;
 };
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target, mod));
 var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
 
 // index.ts
@@ -23,6 +26,7 @@ __export(trigger_codebuild_exports, {
 });
 module.exports = __toCommonJS(trigger_codebuild_exports);
 var import_client_codebuild = require("@aws-sdk/client-codebuild");
+var import_crypto = __toESM(require("crypto"));
 var cb = new import_client_codebuild.CodeBuildClient({});
 var handler = async (event, context) => {
   console.log(JSON.stringify(event));
@@ -53,7 +57,7 @@ var handler = async (event, context) => {
               },
               {
                 name: "destinationObjectKey",
-                value: props.destinationObjectKey
+                value: `${import_crypto.default.randomBytes(16).toString("hex")}.zip`
               },
               {
                 name: "workingDirectory",

--- a/test/soci-index-build.integ.snapshot/manifest.json
+++ b/test/soci-index-build.integ.snapshot/manifest.json
@@ -33,13 +33,13 @@
           {
             "type": "aws:cdk:asset",
             "data": {
-              "path": "asset.b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
-              "id": "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
+              "path": "asset.16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
+              "id": "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
               "packaging": "zip",
-              "sourceHash": "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
-              "s3BucketParameter": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8",
-              "s3KeyParameter": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034",
-              "artifactHashParameter": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363ArtifactHash63F36728"
+              "sourceHash": "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
+              "s3BucketParameter": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97",
+              "s3KeyParameter": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D",
+              "artifactHashParameter": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fArtifactHash5D107D4A"
             }
           },
           {
@@ -81,22 +81,22 @@
             "data": "DeployTimeBuildCustomResourceHandlerdb740fd554364a848a09e6dfcd01f4f306AEFF37"
           }
         ],
-        "/SociIndexBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3Bucket": [
+        "/SociIndexBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3Bucket": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8"
+            "data": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97"
           }
         ],
-        "/SociIndexBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3VersionKey": [
+        "/SociIndexBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3VersionKey": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+            "data": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
           }
         ],
-        "/SociIndexBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/ArtifactHash": [
+        "/SociIndexBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/ArtifactHash": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363ArtifactHash63F36728"
+            "data": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fArtifactHash5D107D4A"
           }
         ],
         "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Role/Resource": [

--- a/test/soci-index-build.integ.snapshot/tree.json
+++ b/test/soci-index-build.integ.snapshot/tree.json
@@ -227,7 +227,7 @@
                   "aws:cdk:cloudformation:props": {
                     "code": {
                       "s3Bucket": {
-                        "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3BucketF9CF99E8"
+                        "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3BucketE9994E97"
                       },
                       "s3Key": {
                         "Fn::Join": [
@@ -240,7 +240,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+                                      "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
                                     }
                                   ]
                                 }
@@ -253,7 +253,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersb49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363S3VersionKey6F0A4034"
+                                      "Ref": "AssetParameters16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730fS3VersionKey0A39C10D"
                                     }
                                   ]
                                 }
@@ -289,13 +289,13 @@
             "id": "AssetParameters",
             "path": "SociIndexBuildIntegTest/AssetParameters",
             "children": {
-              "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363": {
-                "id": "b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
-                "path": "SociIndexBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363",
+              "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f": {
+                "id": "16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
+                "path": "SociIndexBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f",
                 "children": {
                   "S3Bucket": {
                     "id": "S3Bucket",
-                    "path": "SociIndexBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3Bucket",
+                    "path": "SociIndexBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3Bucket",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -303,7 +303,7 @@
                   },
                   "S3VersionKey": {
                     "id": "S3VersionKey",
-                    "path": "SociIndexBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/S3VersionKey",
+                    "path": "SociIndexBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/S3VersionKey",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -311,7 +311,7 @@
                   },
                   "ArtifactHash": {
                     "id": "ArtifactHash",
-                    "path": "SociIndexBuildIntegTest/AssetParameters/b49cc8147b0bf86afefc1c551a4b5cf9165167cf31a5d50e4bf169f944f6a363/ArtifactHash",
+                    "path": "SociIndexBuildIntegTest/AssetParameters/16b8e50f31d31f0d011e69034b4400b65b3db876ce1a6f50356b6cafe6db730f/ArtifactHash",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"


### PR DESCRIPTION
Fixes #9 

We now use a randomized key for each build artifact s3 object key and pass it to the BucketDeployment construct, ensuring deployment always happens after a build.


