### PR TITLE
feat: use arm64 instances for arm64 platform builds

### DIFF
--- a/src/container-image-build.ts
+++ b/src/container-image-build.ts
@@ -2,7 +2,7 @@ import { createHash } from 'crypto';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { CfnResource, CustomResource, Duration, RemovalPolicy } from 'aws-cdk-lib';
-import { BuildSpec, LinuxArmBuildImage, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
+import { BuildSpec, ComputeType, LinuxArmBuildImage, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
 import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { IRepository, Repository } from 'aws-cdk-lib/aws-ecr';
 import { DockerImageAssetProps } from 'aws-cdk-lib/aws-ecr-assets';
@@ -81,6 +81,7 @@ export class ContainerImageBuild extends Construct implements IGrantable {
       uuid: 'e83729fe-b156-4e70-9bec-452b15847a30',
       projectPurpose: isArm64 ? 'ContainerImageBuildArm64' : 'ContainerImageBuildAmd64',
       environment: {
+        computeType: ComputeType.SMALL,
         buildImage: buildImage,
         privileged: true,
       },

--- a/src/singleton-project.ts
+++ b/src/singleton-project.ts
@@ -46,9 +46,14 @@ export class SingletonProject extends Construct {
     // Things that can be added to the slug later (we have to create a new project per these properties):
     //   * vpc addr
     //   * instance type
+    //   * platform (amd64/arm64)
     // But actually, replacement will not cause any disruption because of its stateless nature.
     let slug = '';
     slug += props.vpc?.node.addr ?? '';
+    // Get platform info from environment.buildImage if available
+    if (props.environment?.buildImage) {
+      slug += props.environment.buildImage.toString().includes('aarch64') ? 'arm64' : 'amd64';
+    }
     return slug;
   }
 

--- a/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
+++ b/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
@@ -1252,7 +1252,7 @@
      "Type": "NO_ARTIFACTS"
     },
     "Environment": {
-     "ComputeType": "BUILD_GENERAL1_LARGE",
+     "ComputeType": "BUILD_GENERAL1_SMALL",
      "Image": "aws/codebuild/amazonlinux2-aarch64-standard:3.0",
      "ImagePullCredentialsType": "CODEBUILD",
      "PrivilegedMode": true,

--- a/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
+++ b/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
@@ -485,7 +485,7 @@
     },
     "imageTag": "0cb4b8f0df7fe44ecbf1d4d1bb949c3c",
     "codeBuildProjectName": {
-     "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+     "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
     },
     "sourceS3Url": {
      "Fn::Join": [
@@ -571,13 +571,19 @@
        "Resource": [
         {
          "Fn::GetAtt": [
-          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB",
+          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2",
           "Arn"
          ]
         },
         {
          "Fn::GetAtt": [
-          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD",
+          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187",
+          "Arn"
+         ]
+        },
+        {
+         "Fn::GetAtt": [
+          "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549",
           "Arn"
          ]
         }
@@ -650,7 +656,7 @@
     "DeployTimeBuildCustomResourceHandlerdb740fd554364a848a09e6dfcd01f4f3ServiceRoleB008BAA4"
    ]
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleD95F32B9": {
    "Type": "AWS::IAM::Role",
    "Properties": {
     "AssumeRolePolicyDocument": {
@@ -681,7 +687,7 @@
     ]
    }
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleDefaultPolicy9F1BA63A": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicyBD233B55": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
     "PolicyDocument": {
@@ -712,7 +718,7 @@
            },
            ":log-group:/aws/codebuild/",
            {
-            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
            },
            ":*"
           ]
@@ -736,7 +742,7 @@
            },
            ":log-group:/aws/codebuild/",
            {
-            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
            }
           ]
          ]
@@ -770,7 +776,7 @@
           },
           ":report-group/",
           {
-           "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+           "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
           },
           "-*"
          ]
@@ -845,15 +851,15 @@
      ],
      "Version": "2012-10-17"
     },
-    "PolicyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleDefaultPolicy9F1BA63A",
+    "PolicyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicyBD233B55",
     "Roles": [
      {
-      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276"
+      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleD95F32B9"
      }
     ]
    }
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2": {
    "Type": "AWS::CodeBuild::Project",
    "Properties": {
     "Artifacts": {
@@ -868,7 +874,7 @@
     },
     "ServiceRole": {
      "Fn::GetAtt": [
-      "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276",
+      "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleD95F32B9",
       "Arn"
      ]
     },
@@ -992,7 +998,7 @@
     },
     "imageTag": "ca38901771f07ed68abee97d650d90e0",
     "codeBuildProjectName": {
-     "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+     "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
     },
     "sourceS3Url": {
      "Fn::Join": [
@@ -1035,6 +1041,238 @@
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
+  },
+  "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleC5F7BBFE": {
+   "Type": "AWS::IAM::Role",
+   "Properties": {
+    "AssumeRolePolicyDocument": {
+     "Statement": [
+      {
+       "Action": "sts:AssumeRole",
+       "Effect": "Allow",
+       "Principal": {
+        "Service": "codebuild.amazonaws.com"
+       }
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "ManagedPolicyArns": [
+     {
+      "Fn::Join": [
+       "",
+       [
+        "arn:",
+        {
+         "Ref": "AWS::Partition"
+        },
+        ":iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly"
+       ]
+      ]
+     }
+    ]
+   }
+  },
+  "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicy2316728F": {
+   "Type": "AWS::IAM::Policy",
+   "Properties": {
+    "PolicyDocument": {
+     "Statement": [
+      {
+       "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":logs:",
+           {
+            "Ref": "AWS::Region"
+           },
+           ":",
+           {
+            "Ref": "AWS::AccountId"
+           },
+           ":log-group:/aws/codebuild/",
+           {
+            "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
+           },
+           ":*"
+          ]
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":logs:",
+           {
+            "Ref": "AWS::Region"
+           },
+           ":",
+           {
+            "Ref": "AWS::AccountId"
+           },
+           ":log-group:/aws/codebuild/",
+           {
+            "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
+           }
+          ]
+         ]
+        }
+       ]
+      },
+      {
+       "Action": [
+        "codebuild:BatchPutCodeCoverages",
+        "codebuild:BatchPutTestCases",
+        "codebuild:CreateReport",
+        "codebuild:CreateReportGroup",
+        "codebuild:UpdateReport"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::Join": [
+         "",
+         [
+          "arn:",
+          {
+           "Ref": "AWS::Partition"
+          },
+          ":codebuild:",
+          {
+           "Ref": "AWS::Region"
+          },
+          ":",
+          {
+           "Ref": "AWS::AccountId"
+          },
+          ":report-group/",
+          {
+           "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
+          },
+          "-*"
+         ]
+        ]
+       }
+      },
+      {
+       "Action": [
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:BatchGetImage",
+        "ecr:CompleteLayerUpload",
+        "ecr:DescribeImages",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:InitiateLayerUpload",
+        "ecr:PutImage",
+        "ecr:UploadLayerPart"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "BuildRepository4E6D17C2",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": "ecr:GetAuthorizationToken",
+       "Effect": "Allow",
+       "Resource": "*"
+      },
+      {
+       "Action": [
+        "s3:GetBucket*",
+        "s3:GetObject*",
+        "s3:List*"
+       ],
+       "Effect": "Allow",
+       "Resource": [
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Ref": "AssetParametersf7fa10e7cd7b9b27f49a4a335f4aa9795fb7e68a665c34ca8bf5711f0aa6aeabS3Bucket1FF22598"
+           },
+           "/*"
+          ]
+         ]
+        },
+        {
+         "Fn::Join": [
+          "",
+          [
+           "arn:",
+           {
+            "Ref": "AWS::Partition"
+           },
+           ":s3:::",
+           {
+            "Ref": "AssetParametersf7fa10e7cd7b9b27f49a4a335f4aa9795fb7e68a665c34ca8bf5711f0aa6aeabS3Bucket1FF22598"
+           }
+          ]
+         ]
+        }
+       ]
+      }
+     ],
+     "Version": "2012-10-17"
+    },
+    "PolicyName": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicy2316728F",
+    "Roles": [
+     {
+      "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleC5F7BBFE"
+     }
+    ]
+   }
+  },
+  "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549": {
+   "Type": "AWS::CodeBuild::Project",
+   "Properties": {
+    "Artifacts": {
+     "Type": "NO_ARTIFACTS"
+    },
+    "Environment": {
+     "ComputeType": "BUILD_GENERAL1_LARGE",
+     "Image": "aws/codebuild/amazonlinux2-aarch64-standard:3.0",
+     "ImagePullCredentialsType": "CODEBUILD",
+     "PrivilegedMode": true,
+     "Type": "ARM_CONTAINER"
+    },
+    "ServiceRole": {
+     "Fn::GetAtt": [
+      "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleC5F7BBFE",
+      "Arn"
+     ]
+    },
+    "Source": {
+     "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"current_dir=$(pwd)\",\n        \"echo \\\"$input\\\"\",\n        \"mkdir workdir\",\n        \"cd workdir\",\n        \"aws s3 cp \\\"$sourceS3Url\\\" temp.zip\",\n        \"unzip temp.zip\",\n        \"ls -la\",\n        \"aws ecr get-login-password | docker login --username AWS --password-stdin $repositoryAuthUri\",\n        \"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws\",\n        \"docker buildx create --use\",\n        \"docker buildx ls\",\n        \"eval \\\"$buildCommand\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"echo Build completed on `date`\",\n        \"\\nSTATUS='SUCCESS'\\nif [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ] # Test if the build is failing\\nthen\\nSTATUS='FAILED'\\nREASON=\\\"ContainerImageBuild failed. See CloudWatch Log stream for the detailed reason: \\nhttps://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#logsV2:log-groups/log-group/\\\\$252Faws\\\\$252Fcodebuild\\\\$252F$projectName/log-events/$CODEBUILD_LOG_PATH\\\"\\nfi\\ncat <<EOF > payload.json\\n{\\n  \\\"StackId\\\": \\\"$stackId\\\",\\n  \\\"RequestId\\\": \\\"$requestId\\\",\\n  \\\"LogicalResourceId\\\":\\\"$logicalResourceId\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$imageTag\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"$REASON\\\",\\n  \\\"Data\\\": {\\n    \\\"ImageTag\\\": \\\"$imageTag\\\"\\n  }\\n}\\nEOF\\ncurl -v -i -X PUT -H 'Content-Type:' -d \\\"@payload.json\\\" \\\"$responseURL\\\"\\n              \"\n      ]\n    }\n  }\n}",
+     "Type": "NO_SOURCE"
+    },
+    "Cache": {
+     "Type": "NO_CACHE"
+    },
+    "EncryptionKey": "alias/aws/s3"
+   }
   },
   "FunctionServiceRole675BB04A": {
    "Type": "AWS::IAM::Role",
@@ -1447,7 +1685,7 @@
     },
     "imageTag": "0935d471547c278ca8652335f6d474db",
     "codeBuildProjectName": {
-     "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+     "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
     },
     "sourceS3Url": {
      "Fn::Join": [
@@ -1491,7 +1729,7 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1": {
    "Type": "AWS::IAM::Role",
    "Properties": {
     "AssumeRolePolicyDocument": {
@@ -1522,7 +1760,7 @@
     ]
    }
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRoleDefaultPolicyBD1A2120": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64RoleDefaultPolicyF7E07B6C": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
     "PolicyDocument": {
@@ -1630,7 +1868,7 @@
            },
            ":log-group:/aws/codebuild/",
            {
-            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
            },
            ":*"
           ]
@@ -1654,7 +1892,7 @@
            },
            ":log-group:/aws/codebuild/",
            {
-            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
            }
           ]
          ]
@@ -1688,7 +1926,7 @@
           },
           ":report-group/",
           {
-           "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+           "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
           },
           "-*"
          ]
@@ -1763,18 +2001,18 @@
      ],
      "Version": "2012-10-17"
     },
-    "PolicyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRoleDefaultPolicyBD1A2120",
+    "PolicyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64RoleDefaultPolicyF7E07B6C",
     "Roles": [
      {
-      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC"
+      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1"
      }
     ]
    }
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dSecurityGroup0214D6FC": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64SecurityGroup48FE16CC": {
    "Type": "AWS::EC2::SecurityGroup",
    "Properties": {
-    "GroupDescription": "Automatic generated security group for CodeBuild ContainerImageBuildIntegTestContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dC6E6E137",
+    "GroupDescription": "Automatic generated security group for CodeBuild ContainerImageBuildIntegTestContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64A2A27E6C",
     "SecurityGroupEgress": [
      {
       "CidrIp": "0.0.0.0/0",
@@ -1787,7 +2025,7 @@
     }
    }
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187": {
    "Type": "AWS::CodeBuild::Project",
    "Properties": {
     "Artifacts": {
@@ -1802,7 +2040,7 @@
     },
     "ServiceRole": {
      "Fn::GetAtt": [
-      "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC",
+      "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1",
       "Arn"
      ]
     },
@@ -1818,7 +2056,7 @@
      "SecurityGroupIds": [
       {
        "Fn::GetAtt": [
-        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dSecurityGroup0214D6FC",
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64SecurityGroup48FE16CC",
         "GroupId"
        ]
       }
@@ -1837,10 +2075,10 @@
     }
    },
    "DependsOn": [
-    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dPolicyDocumentE28495DA"
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64PolicyDocument194E3D91"
    ]
   },
-  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dPolicyDocumentE28495DA": {
+  "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64PolicyDocument194E3D91": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
     "PolicyDocument": {
@@ -1861,10 +2099,10 @@
      ],
      "Version": "2012-10-17"
     },
-    "PolicyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dPolicyDocumentE28495DA",
+    "PolicyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64PolicyDocument194E3D91",
     "Roles": [
      {
-      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC"
+      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1"
      }
     ]
    }

--- a/test/container-image-build.integ.snapshot/manifest.json
+++ b/test/container-image-build.integ.snapshot/manifest.json
@@ -233,28 +233,46 @@
             "data": "AssetParametersf7fa10e7cd7b9b27f49a4a335f4aa9795fb7e68a665c34ca8bf5711f0aa6aeabArtifactHashC9CEFA00"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Role/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Role/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleD95F32B9"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Role/DefaultPolicy/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Role/DefaultPolicy/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleDefaultPolicy9F1BA63A"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicyBD233B55"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
           }
         ],
         "/ContainerImageBuildIntegTest/BuildArm/Resource/Default": [
           {
             "type": "aws:cdk:logicalId",
             "data": "BuildArmF8ABF624"
+          }
+        ],
+        "/ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Role/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleC5F7BBFE"
+          }
+        ],
+        "/ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Role/DefaultPolicy/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicy2316728F"
+          }
+        ],
+        "/ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
           }
         ],
         "/ContainerImageBuildIntegTest/Function/ServiceRole/Resource": [
@@ -317,94 +335,103 @@
             "data": "BuildVpc1895B133"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Role/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Role/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Role/DefaultPolicy/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Role/DefaultPolicy/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRoleDefaultPolicyBD1A2120"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64RoleDefaultPolicyF7E07B6C"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/SecurityGroup/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/SecurityGroup/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dSecurityGroup0214D6FC"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64SecurityGroup48FE16CC"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
           }
         ],
-        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/PolicyDocument/Resource": [
+        "/ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/PolicyDocument/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dPolicyDocumentE28495DA"
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64PolicyDocument194E3D91"
           }
         ],
-        "Vpc8378EB38": [
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "Vpc8378EB38",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276",
             "trace": [
               "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
             ]
           }
         ],
-        "VpcpublicSubnet1Subnet2BB74ED7": [
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleDefaultPolicy9F1BA63A": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "VpcpublicSubnet1Subnet2BB74ED7",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleDefaultPolicy9F1BA63A",
             "trace": [
               "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
             ]
           }
         ],
-        "VpcpublicSubnet1RouteTable15C15F8E": [
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "VpcpublicSubnet1RouteTable15C15F8E",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB",
             "trace": [
               "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
             ]
           }
         ],
-        "VpcpublicSubnet1RouteTableAssociation4E83B6E4": [
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "VpcpublicSubnet1RouteTableAssociation4E83B6E4",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC",
             "trace": [
               "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
             ]
           }
         ],
-        "VpcpublicSubnet1DefaultRouteB88F9E93": [
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRoleDefaultPolicyBD1A2120": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "VpcpublicSubnet1DefaultRouteB88F9E93",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRoleDefaultPolicyBD1A2120",
             "trace": [
               "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
             ]
           }
         ],
-        "VpcIGWD7BA715C": [
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dSecurityGroup0214D6FC": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "VpcIGWD7BA715C",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dSecurityGroup0214D6FC",
             "trace": [
               "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
             ]
           }
         ],
-        "VpcVPCGWBF912B6E": [
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "VpcVPCGWBF912B6E",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
+        ],
+        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dPolicyDocumentE28495DA": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dPolicyDocumentE28495DA",
             "trace": [
               "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
             ]

--- a/test/container-image-build.integ.snapshot/tree.json
+++ b/test/container-image-build.integ.snapshot/tree.json
@@ -1614,7 +1614,7 @@
                       "image": "aws/codebuild/amazonlinux2-aarch64-standard:3.0",
                       "imagePullCredentialsType": "CODEBUILD",
                       "privilegedMode": true,
-                      "computeType": "BUILD_GENERAL1_LARGE"
+                      "computeType": "BUILD_GENERAL1_SMALL"
                     },
                     "serviceRole": {
                       "Fn::GetAtt": [

--- a/test/container-image-build.integ.snapshot/tree.json
+++ b/test/container-image-build.integ.snapshot/tree.json
@@ -785,13 +785,19 @@
                                   "Resource": [
                                     {
                                       "Fn::GetAtt": [
-                                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB",
+                                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2",
                                         "Arn"
                                       ]
                                     },
                                     {
                                       "Fn::GetAtt": [
-                                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD",
+                                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187",
+                                        "Arn"
+                                      ]
+                                    },
+                                    {
+                                      "Fn::GetAtt": [
+                                        "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549",
                                         "Arn"
                                       ]
                                     }
@@ -995,17 +1001,17 @@
               "version": "10.0.5"
             }
           },
-          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30": {
-            "id": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30",
-            "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30",
+          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64": {
+            "id": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64",
+            "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64",
             "children": {
               "Role": {
                 "id": "Role",
-                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Role",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Role",
                 "children": {
                   "Resource": {
                     "id": "Resource",
-                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Role/Resource",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Role/Resource",
                     "attributes": {
                       "aws:cdk:cloudformation:type": "AWS::IAM::Role",
                       "aws:cdk:cloudformation:props": {
@@ -1044,11 +1050,11 @@
                   },
                   "DefaultPolicy": {
                     "id": "DefaultPolicy",
-                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Role/DefaultPolicy",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Role/DefaultPolicy",
                     "children": {
                       "Resource": {
                         "id": "Resource",
-                        "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Role/DefaultPolicy/Resource",
+                        "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Role/DefaultPolicy/Resource",
                         "attributes": {
                           "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
                           "aws:cdk:cloudformation:props": {
@@ -1080,7 +1086,7 @@
                                           },
                                           ":log-group:/aws/codebuild/",
                                           {
-                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
                                           },
                                           ":*"
                                         ]
@@ -1104,7 +1110,7 @@
                                           },
                                           ":log-group:/aws/codebuild/",
                                           {
-                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
                                           }
                                         ]
                                       ]
@@ -1138,7 +1144,7 @@
                                         },
                                         ":report-group/",
                                         {
-                                          "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30F1D2BABB"
+                                          "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
                                         },
                                         "-*"
                                       ]
@@ -1213,10 +1219,10 @@
                               ],
                               "Version": "2012-10-17"
                             },
-                            "policyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleDefaultPolicy9F1BA63A",
+                            "policyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicyBD233B55",
                             "roles": [
                               {
-                                "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276"
+                                "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleD95F32B9"
                               }
                             ]
                           }
@@ -1240,7 +1246,7 @@
               },
               "Resource": {
                 "id": "Resource",
-                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30/Resource",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64/Resource",
                 "attributes": {
                   "aws:cdk:cloudformation:type": "AWS::CodeBuild::Project",
                   "aws:cdk:cloudformation:props": {
@@ -1256,7 +1262,7 @@
                     },
                     "serviceRole": {
                       "Fn::GetAtt": [
-                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30RoleB1437276",
+                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleD95F32B9",
                         "Arn"
                       ]
                     },
@@ -1349,6 +1355,292 @@
             "constructInfo": {
               "fqn": "constructs.Construct",
               "version": "10.0.5"
+            }
+          },
+          "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64": {
+            "id": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64",
+            "path": "ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64",
+            "children": {
+              "Role": {
+                "id": "Role",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Role",
+                "children": {
+                  "Resource": {
+                    "id": "Resource",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Role/Resource",
+                    "attributes": {
+                      "aws:cdk:cloudformation:type": "AWS::IAM::Role",
+                      "aws:cdk:cloudformation:props": {
+                        "assumeRolePolicyDocument": {
+                          "Statement": [
+                            {
+                              "Action": "sts:AssumeRole",
+                              "Effect": "Allow",
+                              "Principal": {
+                                "Service": "codebuild.amazonaws.com"
+                              }
+                            }
+                          ],
+                          "Version": "2012-10-17"
+                        },
+                        "managedPolicyArns": [
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "arn:",
+                                {
+                                  "Ref": "AWS::Partition"
+                                },
+                                ":iam::aws:policy/AmazonElasticContainerRegistryPublicReadOnly"
+                              ]
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.CfnRole",
+                      "version": "2.38.0"
+                    }
+                  },
+                  "DefaultPolicy": {
+                    "id": "DefaultPolicy",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Role/DefaultPolicy",
+                    "children": {
+                      "Resource": {
+                        "id": "Resource",
+                        "path": "ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Role/DefaultPolicy/Resource",
+                        "attributes": {
+                          "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
+                          "aws:cdk:cloudformation:props": {
+                            "policyDocument": {
+                              "Statement": [
+                                {
+                                  "Action": [
+                                    "logs:CreateLogGroup",
+                                    "logs:CreateLogStream",
+                                    "logs:PutLogEvents"
+                                  ],
+                                  "Effect": "Allow",
+                                  "Resource": [
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "arn:",
+                                          {
+                                            "Ref": "AWS::Partition"
+                                          },
+                                          ":logs:",
+                                          {
+                                            "Ref": "AWS::Region"
+                                          },
+                                          ":",
+                                          {
+                                            "Ref": "AWS::AccountId"
+                                          },
+                                          ":log-group:/aws/codebuild/",
+                                          {
+                                            "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
+                                          },
+                                          ":*"
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "arn:",
+                                          {
+                                            "Ref": "AWS::Partition"
+                                          },
+                                          ":logs:",
+                                          {
+                                            "Ref": "AWS::Region"
+                                          },
+                                          ":",
+                                          {
+                                            "Ref": "AWS::AccountId"
+                                          },
+                                          ":log-group:/aws/codebuild/",
+                                          {
+                                            "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "Action": [
+                                    "codebuild:BatchPutCodeCoverages",
+                                    "codebuild:BatchPutTestCases",
+                                    "codebuild:CreateReport",
+                                    "codebuild:CreateReportGroup",
+                                    "codebuild:UpdateReport"
+                                  ],
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Fn::Join": [
+                                      "",
+                                      [
+                                        "arn:",
+                                        {
+                                          "Ref": "AWS::Partition"
+                                        },
+                                        ":codebuild:",
+                                        {
+                                          "Ref": "AWS::Region"
+                                        },
+                                        ":",
+                                        {
+                                          "Ref": "AWS::AccountId"
+                                        },
+                                        ":report-group/",
+                                        {
+                                          "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
+                                        },
+                                        "-*"
+                                      ]
+                                    ]
+                                  }
+                                },
+                                {
+                                  "Action": [
+                                    "ecr:BatchCheckLayerAvailability",
+                                    "ecr:BatchGetImage",
+                                    "ecr:CompleteLayerUpload",
+                                    "ecr:DescribeImages",
+                                    "ecr:GetDownloadUrlForLayer",
+                                    "ecr:InitiateLayerUpload",
+                                    "ecr:PutImage",
+                                    "ecr:UploadLayerPart"
+                                  ],
+                                  "Effect": "Allow",
+                                  "Resource": {
+                                    "Fn::GetAtt": [
+                                      "BuildRepository4E6D17C2",
+                                      "Arn"
+                                    ]
+                                  }
+                                },
+                                {
+                                  "Action": "ecr:GetAuthorizationToken",
+                                  "Effect": "Allow",
+                                  "Resource": "*"
+                                },
+                                {
+                                  "Action": [
+                                    "s3:GetBucket*",
+                                    "s3:GetObject*",
+                                    "s3:List*"
+                                  ],
+                                  "Effect": "Allow",
+                                  "Resource": [
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "arn:",
+                                          {
+                                            "Ref": "AWS::Partition"
+                                          },
+                                          ":s3:::",
+                                          {
+                                            "Ref": "AssetParametersf7fa10e7cd7b9b27f49a4a335f4aa9795fb7e68a665c34ca8bf5711f0aa6aeabS3Bucket1FF22598"
+                                          },
+                                          "/*"
+                                        ]
+                                      ]
+                                    },
+                                    {
+                                      "Fn::Join": [
+                                        "",
+                                        [
+                                          "arn:",
+                                          {
+                                            "Ref": "AWS::Partition"
+                                          },
+                                          ":s3:::",
+                                          {
+                                            "Ref": "AssetParametersf7fa10e7cd7b9b27f49a4a335f4aa9795fb7e68a665c34ca8bf5711f0aa6aeabS3Bucket1FF22598"
+                                          }
+                                        ]
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ],
+                              "Version": "2012-10-17"
+                            },
+                            "policyName": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicy2316728F",
+                            "roles": [
+                              {
+                                "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleC5F7BBFE"
+                              }
+                            ]
+                          }
+                        },
+                        "constructInfo": {
+                          "fqn": "aws-cdk-lib.aws_iam.CfnPolicy",
+                          "version": "2.38.0"
+                        }
+                      }
+                    },
+                    "constructInfo": {
+                      "fqn": "aws-cdk-lib.aws_iam.Policy",
+                      "version": "2.38.0"
+                    }
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_iam.Role",
+                  "version": "2.38.0"
+                }
+              },
+              "Resource": {
+                "id": "Resource",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64/Resource",
+                "attributes": {
+                  "aws:cdk:cloudformation:type": "AWS::CodeBuild::Project",
+                  "aws:cdk:cloudformation:props": {
+                    "artifacts": {
+                      "type": "NO_ARTIFACTS"
+                    },
+                    "environment": {
+                      "type": "ARM_CONTAINER",
+                      "image": "aws/codebuild/amazonlinux2-aarch64-standard:3.0",
+                      "imagePullCredentialsType": "CODEBUILD",
+                      "privilegedMode": true,
+                      "computeType": "BUILD_GENERAL1_LARGE"
+                    },
+                    "serviceRole": {
+                      "Fn::GetAtt": [
+                        "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleC5F7BBFE",
+                        "Arn"
+                      ]
+                    },
+                    "source": {
+                      "type": "NO_SOURCE",
+                      "buildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"current_dir=$(pwd)\",\n        \"echo \\\"$input\\\"\",\n        \"mkdir workdir\",\n        \"cd workdir\",\n        \"aws s3 cp \\\"$sourceS3Url\\\" temp.zip\",\n        \"unzip temp.zip\",\n        \"ls -la\",\n        \"aws ecr get-login-password | docker login --username AWS --password-stdin $repositoryAuthUri\",\n        \"aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws\",\n        \"docker buildx create --use\",\n        \"docker buildx ls\",\n        \"eval \\\"$buildCommand\\\"\"\n      ]\n    },\n    \"post_build\": {\n      \"commands\": [\n        \"echo Build completed on `date`\",\n        \"\\nSTATUS='SUCCESS'\\nif [ $CODEBUILD_BUILD_SUCCEEDING -ne 1 ] # Test if the build is failing\\nthen\\nSTATUS='FAILED'\\nREASON=\\\"ContainerImageBuild failed. See CloudWatch Log stream for the detailed reason: \\nhttps://$AWS_REGION.console.aws.amazon.com/cloudwatch/home?region=$AWS_REGION#logsV2:log-groups/log-group/\\\\$252Faws\\\\$252Fcodebuild\\\\$252F$projectName/log-events/$CODEBUILD_LOG_PATH\\\"\\nfi\\ncat <<EOF > payload.json\\n{\\n  \\\"StackId\\\": \\\"$stackId\\\",\\n  \\\"RequestId\\\": \\\"$requestId\\\",\\n  \\\"LogicalResourceId\\\":\\\"$logicalResourceId\\\",\\n  \\\"PhysicalResourceId\\\": \\\"$imageTag\\\",\\n  \\\"Status\\\": \\\"$STATUS\\\",\\n  \\\"Reason\\\": \\\"$REASON\\\",\\n  \\\"Data\\\": {\\n    \\\"ImageTag\\\": \\\"$imageTag\\\"\\n  }\\n}\\nEOF\\ncurl -v -i -X PUT -H 'Content-Type:' -d \\\"@payload.json\\\" \\\"$responseURL\\\"\\n              \"\n      ]\n    }\n  }\n}"
+                    },
+                    "cache": {
+                      "type": "NO_CACHE"
+                    },
+                    "encryptionKey": "alias/aws/s3"
+                  }
+                },
+                "constructInfo": {
+                  "fqn": "aws-cdk-lib.aws_codebuild.CfnProject",
+                  "version": "2.38.0"
+                }
+              }
+            },
+            "constructInfo": {
+              "fqn": "aws-cdk-lib.aws_codebuild.Project",
+              "version": "2.38.0"
             }
           },
           "Function": {
@@ -1887,17 +2179,17 @@
               "version": "10.0.5"
             }
           },
-          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d": {
-            "id": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d",
-            "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d",
+          "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64": {
+            "id": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64",
+            "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64",
             "children": {
               "Role": {
                 "id": "Role",
-                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Role",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Role",
                 "children": {
                   "Resource": {
                     "id": "Resource",
-                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Role/Resource",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Role/Resource",
                     "attributes": {
                       "aws:cdk:cloudformation:type": "AWS::IAM::Role",
                       "aws:cdk:cloudformation:props": {
@@ -1936,11 +2228,11 @@
                   },
                   "DefaultPolicy": {
                     "id": "DefaultPolicy",
-                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Role/DefaultPolicy",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Role/DefaultPolicy",
                     "children": {
                       "Resource": {
                         "id": "Resource",
-                        "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Role/DefaultPolicy/Resource",
+                        "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Role/DefaultPolicy/Resource",
                         "attributes": {
                           "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
                           "aws:cdk:cloudformation:props": {
@@ -2049,7 +2341,7 @@
                                           },
                                           ":log-group:/aws/codebuild/",
                                           {
-                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
                                           },
                                           ":*"
                                         ]
@@ -2073,7 +2365,7 @@
                                           },
                                           ":log-group:/aws/codebuild/",
                                           {
-                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+                                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
                                           }
                                         ]
                                       ]
@@ -2107,7 +2399,7 @@
                                         },
                                         ":report-group/",
                                         {
-                                          "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d703E47BD"
+                                          "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
                                         },
                                         "-*"
                                       ]
@@ -2182,10 +2474,10 @@
                               ],
                               "Version": "2012-10-17"
                             },
-                            "policyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRoleDefaultPolicyBD1A2120",
+                            "policyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64RoleDefaultPolicyF7E07B6C",
                             "roles": [
                               {
-                                "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC"
+                                "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1"
                               }
                             ]
                           }
@@ -2209,15 +2501,15 @@
               },
               "SecurityGroup": {
                 "id": "SecurityGroup",
-                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/SecurityGroup",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/SecurityGroup",
                 "children": {
                   "Resource": {
                     "id": "Resource",
-                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/SecurityGroup/Resource",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/SecurityGroup/Resource",
                     "attributes": {
                       "aws:cdk:cloudformation:type": "AWS::EC2::SecurityGroup",
                       "aws:cdk:cloudformation:props": {
-                        "groupDescription": "Automatic generated security group for CodeBuild ContainerImageBuildIntegTestContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dC6E6E137",
+                        "groupDescription": "Automatic generated security group for CodeBuild ContainerImageBuildIntegTestContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64A2A27E6C",
                         "securityGroupEgress": [
                           {
                             "cidrIp": "0.0.0.0/0",
@@ -2243,7 +2535,7 @@
               },
               "Resource": {
                 "id": "Resource",
-                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/Resource",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/Resource",
                 "attributes": {
                   "aws:cdk:cloudformation:type": "AWS::CodeBuild::Project",
                   "aws:cdk:cloudformation:props": {
@@ -2259,7 +2551,7 @@
                     },
                     "serviceRole": {
                       "Fn::GetAtt": [
-                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC",
+                        "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1",
                         "Arn"
                       ]
                     },
@@ -2286,7 +2578,7 @@
                       "securityGroupIds": [
                         {
                           "Fn::GetAtt": [
-                            "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dSecurityGroup0214D6FC",
+                            "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64SecurityGroup48FE16CC",
                             "GroupId"
                           ]
                         }
@@ -2301,11 +2593,11 @@
               },
               "PolicyDocument": {
                 "id": "PolicyDocument",
-                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/PolicyDocument",
+                "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/PolicyDocument",
                 "children": {
                   "Resource": {
                     "id": "Resource",
-                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37d/PolicyDocument/Resource",
+                    "path": "ContainerImageBuildIntegTest/ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64/PolicyDocument/Resource",
                     "attributes": {
                       "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
                       "aws:cdk:cloudformation:props": {
@@ -2327,10 +2619,10 @@
                           ],
                           "Version": "2012-10-17"
                         },
-                        "policyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dPolicyDocumentE28495DA",
+                        "policyName": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64PolicyDocument194E3D91",
                         "roles": [
                           {
-                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37dRole5BED91FC"
+                            "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1"
                           }
                         ]
                       }

--- a/test/soci-index-build.integ.snapshot/SociIndexBuildIntegTest.template.json
+++ b/test/soci-index-build.integ.snapshot/SociIndexBuildIntegTest.template.json
@@ -13,7 +13,7 @@
     "imageTag": "a8bbd8136347d097316685416937f7ad1e2612d23493dcc4e0ef33d290c09b05",
     "repositoryName": "aws-cdk/assets",
     "codeBuildProjectName": {
-     "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+     "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
     }
    },
    "UpdateReplacePolicy": "Delete",
@@ -60,7 +60,7 @@
        "Effect": "Allow",
        "Resource": {
         "Fn::GetAtt": [
-         "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD",
+         "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA",
          "Arn"
         ]
        }
@@ -132,7 +132,7 @@
     "DeployTimeBuildCustomResourceHandlerdb740fd554364a848a09e6dfcd01f4f3ServiceRoleB008BAA4"
    ]
   },
-  "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16": {
+  "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleBDD942DA": {
    "Type": "AWS::IAM::Role",
    "Properties": {
     "AssumeRolePolicyDocument": {
@@ -149,7 +149,7 @@
     }
    }
   },
-  "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRoleDefaultPolicyC13902A7": {
+  "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleDefaultPolicy93E560B4": {
    "Type": "AWS::IAM::Policy",
    "Properties": {
     "PolicyDocument": {
@@ -180,7 +180,7 @@
            },
            ":log-group:/aws/codebuild/",
            {
-            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
            },
            ":*"
           ]
@@ -204,7 +204,7 @@
            },
            ":log-group:/aws/codebuild/",
            {
-            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
            }
           ]
          ]
@@ -238,7 +238,7 @@
           },
           ":report-group/",
           {
-           "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+           "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
           },
           "-*"
          ]
@@ -286,15 +286,15 @@
      ],
      "Version": "2012-10-17"
     },
-    "PolicyName": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRoleDefaultPolicyC13902A7",
+    "PolicyName": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleDefaultPolicy93E560B4",
     "Roles": [
      {
-      "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16"
+      "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleBDD942DA"
      }
     ]
    }
   },
-  "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD": {
+  "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA": {
    "Type": "AWS::CodeBuild::Project",
    "Properties": {
     "Artifacts": {
@@ -309,7 +309,7 @@
     },
     "ServiceRole": {
      "Fn::GetAtt": [
-      "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16",
+      "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleBDD942DA",
       "Arn"
      ]
     },
@@ -336,7 +336,7 @@
     "imageTag": "cf17887cc251b0d2ad6a734dbfd8c28d46168a4e632883267d3a06e454b1c3ad",
     "repositoryName": "aws-cdk/assets",
     "codeBuildProjectName": {
-     "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+     "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
     }
    },
    "UpdateReplacePolicy": "Delete",

--- a/test/soci-index-build.integ.snapshot/manifest.json
+++ b/test/soci-index-build.integ.snapshot/manifest.json
@@ -99,28 +99,55 @@
             "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F"
           }
         ],
-        "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Role/Resource": [
+        "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Role/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16"
+            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleBDD942DA"
           }
         ],
-        "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Role/DefaultPolicy/Resource": [
+        "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Role/DefaultPolicy/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRoleDefaultPolicyC13902A7"
+            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleDefaultPolicy93E560B4"
           }
         ],
-        "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Resource": [
+        "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Resource": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
           }
         ],
         "/SociIndexBuildIntegTest/Image2/Index/Resource/Default": [
           {
             "type": "aws:cdk:logicalId",
             "data": "Image2Index42EE498C"
+          }
+        ],
+        "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
+        ],
+        "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRoleDefaultPolicyC13902A7": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRoleDefaultPolicyC13902A7",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
+          }
+        ],
+        "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD",
+            "trace": [
+              "!!DESTRUCTIVE_CHANGES: WILL_DESTROY"
+            ]
           }
         ]
       },

--- a/test/soci-index-build.integ.snapshot/tree.json
+++ b/test/soci-index-build.integ.snapshot/tree.json
@@ -160,7 +160,7 @@
                                   "Effect": "Allow",
                                   "Resource": {
                                     "Fn::GetAtt": [
-                                      "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD",
+                                      "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA",
                                       "Arn"
                                     ]
                                   }
@@ -329,17 +329,17 @@
               "version": "10.0.5"
             }
           },
-          "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c": {
-            "id": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c",
-            "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c",
+          "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64": {
+            "id": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64",
+            "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64",
             "children": {
               "Role": {
                 "id": "Role",
-                "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Role",
+                "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Role",
                 "children": {
                   "Resource": {
                     "id": "Resource",
-                    "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Role/Resource",
+                    "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Role/Resource",
                     "attributes": {
                       "aws:cdk:cloudformation:type": "AWS::IAM::Role",
                       "aws:cdk:cloudformation:props": {
@@ -364,11 +364,11 @@
                   },
                   "DefaultPolicy": {
                     "id": "DefaultPolicy",
-                    "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Role/DefaultPolicy",
+                    "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Role/DefaultPolicy",
                     "children": {
                       "Resource": {
                         "id": "Resource",
-                        "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Role/DefaultPolicy/Resource",
+                        "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Role/DefaultPolicy/Resource",
                         "attributes": {
                           "aws:cdk:cloudformation:type": "AWS::IAM::Policy",
                           "aws:cdk:cloudformation:props": {
@@ -400,7 +400,7 @@
                                           },
                                           ":log-group:/aws/codebuild/",
                                           {
-                                            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+                                            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
                                           },
                                           ":*"
                                         ]
@@ -424,7 +424,7 @@
                                           },
                                           ":log-group:/aws/codebuild/",
                                           {
-                                            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+                                            "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
                                           }
                                         ]
                                       ]
@@ -458,7 +458,7 @@
                                         },
                                         ":report-group/",
                                         {
-                                          "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cFF24E8AD"
+                                          "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd642F4A8EFA"
                                         },
                                         "-*"
                                       ]
@@ -506,10 +506,10 @@
                               ],
                               "Version": "2012-10-17"
                             },
-                            "policyName": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRoleDefaultPolicyC13902A7",
+                            "policyName": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleDefaultPolicy93E560B4",
                             "roles": [
                               {
-                                "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16"
+                                "Ref": "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleBDD942DA"
                               }
                             ]
                           }
@@ -533,7 +533,7 @@
               },
               "Resource": {
                 "id": "Resource",
-                "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3c/Resource",
+                "path": "SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Resource",
                 "attributes": {
                   "aws:cdk:cloudformation:type": "AWS::CodeBuild::Project",
                   "aws:cdk:cloudformation:props": {
@@ -549,7 +549,7 @@
                     },
                     "serviceRole": {
                       "Fn::GetAtt": [
-                        "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3cRole33DABF16",
+                        "SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64RoleBDD942DA",
                         "Arn"
                       ]
                     },


### PR DESCRIPTION
## Overview
This PR implements issue #31. It adds support for using ARM64 instances when building container images for ARM64 platform.

## Changes
- Extended the `propsToAdditionalString` method in `SingletonProject` class to include platform information (amd64/arm64) in the slug
- Modified `container-image-build.ts` to select the appropriate build image based on the target platform:
  - Use `LinuxArmBuildImage` for ARM64 builds
  - Continue using `LinuxBuildImage` for AMD64 builds
- Set appropriate `projectPurpose` names for ARM64 build projects

This change improves build performance for ARM64 platform images by utilizing native ARM64 build environments.

## Breaking Changes
This PR contains intentional breaking changes. It replaces existing project resources by creating separate CodeBuild projects per platform. This causes snapshot tests to fail, but it's the expected behavior. The snapshot tests will need to be updated.

Closes #31