### PR TITLE
feat: add tagPrefix to ContainerImageBuild

### DIFF
--- a/API.md
+++ b/API.md
@@ -620,6 +620,7 @@ const containerImageBuildProps: ContainerImageBuildProps = { ... }
 | <code><a href="#deploy-time-build.ContainerImageBuildProps.property.directory">directory</a></code> | <code>string</code> | The directory where the Dockerfile is stored. |
 | <code><a href="#deploy-time-build.ContainerImageBuildProps.property.repository">repository</a></code> | <code>aws-cdk-lib.aws_ecr.IRepository</code> | The ECR repository to push the image. |
 | <code><a href="#deploy-time-build.ContainerImageBuildProps.property.tag">tag</a></code> | <code>string</code> | The tag when to push the image. |
+| <code><a href="#deploy-time-build.ContainerImageBuildProps.property.tagPrefix">tagPrefix</a></code> | <code>string</code> | Prefix to add to the image tag. |
 | <code><a href="#deploy-time-build.ContainerImageBuildProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | The VPC where your build job will be deployed. This VPC must have private subnets with NAT Gateways. |
 | <code><a href="#deploy-time-build.ContainerImageBuildProps.property.zstdCompression">zstdCompression</a></code> | <code>boolean</code> | Use zstd for compressing a container image. |
 
@@ -803,6 +804,19 @@ public readonly tag: string;
 - *Default:* use assetHash as tag
 
 The tag when to push the image.
+
+---
+
+##### `tagPrefix`<sup>Optional</sup> <a name="tagPrefix" id="deploy-time-build.ContainerImageBuildProps.property.tagPrefix"></a>
+
+```typescript
+public readonly tagPrefix: string;
+```
+
+- *Type:* string
+- *Default:* no prefix
+
+Prefix to add to the image tag.
 
 ---
 

--- a/AmazonQ.md
+++ b/AmazonQ.md
@@ -6,6 +6,8 @@ This document contains helpful information for developers working on the `deploy
 
 ### PR Title Format
 
+All text in PR title or description must be written in English.
+
 Pull request titles must follow the [Conventional Commits](https://www.conventionalcommits.org/) format. Only the following prefixes are allowed:
 
 - `feat:` - For new features
@@ -33,8 +35,10 @@ PRs with titles not following this format will fail validation checks.
 You should make sure the build succeeds by the following command before commiting a change:
 
 ```bash
-yarn build
+npm run build
 ```
+
+After a successful build, several files such as API.md might be updated. Please check git status and commit them if there are any changes.
 
 ## Testing
 
@@ -47,7 +51,7 @@ When you make changes that intentionally alter the infrastructure (like adding n
 After your changes are approved and merged, update the snapshot tests by running:
 
 ```bash
-yarn integ-runner --update-on-failed
+npx integ-runner --update-on-failed
 ```
 
 ## Common Issues

--- a/src/container-image-build.ts
+++ b/src/container-image-build.ts
@@ -168,10 +168,7 @@ curl -v -i -X PUT -H 'Content-Type:' -d "@payload.json" "$responseURL"
     });
     asset.grantRead(project);
 
-    let imageTag = props.tag ?? this.getImageHash(asset.assetHash, props);
-    if (props.tagPrefix) {
-      imageTag = `${props.tagPrefix}${imageTag}`;
-    }
+    let imageTag = `${props.tagPrefix ?? ''}${props.tag ?? this.getImageHash(asset.assetHash, props)}`;
     const buildCommandOptions = { ...props, tag: imageTag, platform: props.platform?.platform } as any;
     buildCommandOptions.outputs ??= [];
     // to enable zstd compression, buildx directly pushes the artifact image to a registry

--- a/src/container-image-build.ts
+++ b/src/container-image-build.ts
@@ -168,7 +168,7 @@ curl -v -i -X PUT -H 'Content-Type:' -d "@payload.json" "$responseURL"
     });
     asset.grantRead(project);
 
-    let imageTag = `${props.tagPrefix ?? ''}${props.tag ?? this.getImageHash(asset.assetHash, props)}`;
+    const imageTag = `${props.tagPrefix ?? ''}${props.tag ?? this.getImageHash(asset.assetHash, props)}`;
     const buildCommandOptions = { ...props, tag: imageTag, platform: props.platform?.platform } as any;
     buildCommandOptions.outputs ??= [];
     // to enable zstd compression, buildx directly pushes the artifact image to a registry

--- a/src/container-image-build.ts
+++ b/src/container-image-build.ts
@@ -22,6 +22,12 @@ export interface ContainerImageBuildProps extends DockerImageAssetProps {
   readonly tag?: string;
 
   /**
+   * Prefix to add to the image tag
+   * @default no prefix
+   */
+  readonly tagPrefix?: string;
+
+  /**
    * The ECR repository to push the image.
    * @default create a new ECR repository
    */
@@ -162,7 +168,10 @@ curl -v -i -X PUT -H 'Content-Type:' -d "@payload.json" "$responseURL"
     });
     asset.grantRead(project);
 
-    const imageTag = props.tag ?? this.getImageHash(asset.assetHash, props);
+    let imageTag = props.tag ?? this.getImageHash(asset.assetHash, props);
+    if (props.tagPrefix) {
+      imageTag = `${props.tagPrefix}${imageTag}`;
+    }
     const buildCommandOptions = { ...props, tag: imageTag, platform: props.platform?.platform } as any;
     buildCommandOptions.outputs ??= [];
     // to enable zstd compression, buildx directly pushes the artifact image to a registry


### PR DESCRIPTION
# Feature: Add tagPrefix property to ContainerImageBuild

This PR implements issue #35. The change adds a `tagPrefix` property to `ContainerImageBuild`, allowing users to set a prefix for container image tags.

## Changes

- Added `tagPrefix` property to `ContainerImageBuildProps` interface
- Added logic to apply `tagPrefix` to the `imageTag` variable in the constructor

Closes #35