### PR TITLE
fix: remove buildArgs from invalidation keys

### DIFF
--- a/src/container-image-build.ts
+++ b/src/container-image-build.ts
@@ -220,9 +220,11 @@ curl -v -i -X PUT -H 'Content-Type:' -d "@payload.json" "$responseURL"
     if (props.invalidation?.extraHash !== false && props.extraHash) {
       extraHash.user = props.extraHash;
     }
-    if (props.invalidation?.buildArgs !== false && props.buildArgs) {
-      extraHash.buildArgs = props.buildArgs;
-    }
+    // buildArgs often contains tokens, so must be omitted from here.
+    // custom resource properties contain buildArgs, so the build runs anyway.
+    // if (props.invalidation?.buildArgs !== false && props.buildArgs) {
+    //   extraHash.buildArgs = props.buildArgs;
+    // }
     if (props.invalidation?.buildSecrets !== false && props.buildSecrets) {
       extraHash.buildSecrets = props.buildSecrets;
     }

--- a/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
+++ b/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
@@ -431,7 +431,7 @@
        {
         "Ref": "BuildRepository4E6D17C2"
        },
-       ":0cb4b8f0df7fe44ecbf1d4d1bb949c3c,push=true --provenance=false ."
+       ":0935d471547c278ca8652335f6d474db,push=true --provenance=false ."
       ]
      ]
     },
@@ -483,7 +483,7 @@
       ]
      ]
     },
-    "imageTag": "0cb4b8f0df7fe44ecbf1d4d1bb949c3c",
+    "imageTag": "0935d471547c278ca8652335f6d474db",
     "codeBuildProjectName": {
      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
     },
@@ -1569,6 +1569,29 @@
   },
   "BuildVpcRepositoryC4EB5D59": {
    "Type": "AWS::ECR::Repository",
+   "DependsOn": [
+    "VpcV2IGWD1C41C9C",
+    "VpcV2PrivateSubnet1DefaultRoute5D002E26",
+    "VpcV2PrivateSubnet1RouteTable7476B1CF",
+    "VpcV2PrivateSubnet1RouteTableAssociation52F79D41",
+    "VpcV2PrivateSubnet1Subnet10A485FB",
+    "VpcV2PrivateSubnet2DefaultRouteA0C8D70C",
+    "VpcV2PrivateSubnet2RouteTable7B419F52",
+    "VpcV2PrivateSubnet2RouteTableAssociationAA17A176",
+    "VpcV2PrivateSubnet2Subnet038DDA50",
+    "VpcV2PublicSubnet1DefaultRoute00753B94",
+    "VpcV2PublicSubnet1EIPCB084C48",
+    "VpcV2PublicSubnet1NATGatewayD04F745E",
+    "VpcV2PublicSubnet1RouteTable6094F526",
+    "VpcV2PublicSubnet1RouteTableAssociation7CEECFFF",
+    "VpcV2PublicSubnet1SubnetD67FC535",
+    "VpcV2PublicSubnet2DefaultRoute9078EB37",
+    "VpcV2PublicSubnet2RouteTable4FB96B9F",
+    "VpcV2PublicSubnet2RouteTableAssociationE75A579E",
+    "VpcV2PublicSubnet2Subnet63F50919",
+    "VpcV257066EE3",
+    "VpcV2VPCGW167F37E8"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete",
    "Properties": {
@@ -1726,6 +1749,29 @@
      ]
     }
    },
+   "DependsOn": [
+    "VpcV2IGWD1C41C9C",
+    "VpcV2PrivateSubnet1DefaultRoute5D002E26",
+    "VpcV2PrivateSubnet1RouteTable7476B1CF",
+    "VpcV2PrivateSubnet1RouteTableAssociation52F79D41",
+    "VpcV2PrivateSubnet1Subnet10A485FB",
+    "VpcV2PrivateSubnet2DefaultRouteA0C8D70C",
+    "VpcV2PrivateSubnet2RouteTable7B419F52",
+    "VpcV2PrivateSubnet2RouteTableAssociationAA17A176",
+    "VpcV2PrivateSubnet2Subnet038DDA50",
+    "VpcV2PublicSubnet1DefaultRoute00753B94",
+    "VpcV2PublicSubnet1EIPCB084C48",
+    "VpcV2PublicSubnet1NATGatewayD04F745E",
+    "VpcV2PublicSubnet1RouteTable6094F526",
+    "VpcV2PublicSubnet1RouteTableAssociation7CEECFFF",
+    "VpcV2PublicSubnet1SubnetD67FC535",
+    "VpcV2PublicSubnet2DefaultRoute9078EB37",
+    "VpcV2PublicSubnet2RouteTable4FB96B9F",
+    "VpcV2PublicSubnet2RouteTableAssociationE75A579E",
+    "VpcV2PublicSubnet2Subnet63F50919",
+    "VpcV257066EE3",
+    "VpcV2VPCGW167F37E8"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },

--- a/test/integ.container-image-build.ts
+++ b/test/integ.container-image-build.ts
@@ -35,10 +35,12 @@ class TestStack extends Stack {
       logging: new AwsLogDriver({ streamPrefix: 'main' }),
     });
 
-    new ContainerImageBuild(this, 'BuildVpc', {
+    const build = new ContainerImageBuild(this, 'BuildVpc', {
       directory: '../example/example-image',
       vpc,
     });
+    // build must run after NAT gateways are configured
+    build.node.addDependency(vpc);
   }
 }
 


### PR DESCRIPTION
`buildArgs` often contains tokens and it made the image tag unstable. We remove it from the invalidatiion logic.