### PR TITLE
feat: generate image tag every time it triggers a build

### DIFF
--- a/lambda/trigger-codebuild/index.ts
+++ b/lambda/trigger-codebuild/index.ts
@@ -122,6 +122,8 @@ export const handler = async (event: Event, context: any) => {
           });
           break;
         case 'ContainerImageBuild': {
+          const imageTag = props.imageTag ?? `${props.tagPrefix ?? ''}${newPhysicalId}`;
+          const buildCommand = props.buildCommand.replaceAll('<IMAGE_TAG>', imageTag);
           command = new StartBuildCommand({
             projectName: props.codeBuildProjectName,
             environmentVariablesOverride: [
@@ -136,11 +138,11 @@ export const handler = async (event: Event, context: any) => {
               },
               {
                 name: 'buildCommand',
-                value: props.buildCommand,
+                value: buildCommand,
               },
               {
                 name: 'imageTag',
-                value: props.imageTag,
+                value: imageTag,
               },
               {
                 name: 'projectName',

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,8 @@ export type ContainerImageBuildResourceProps = {
   type: 'ContainerImageBuild';
   buildCommand: string;
   repositoryUri: string;
-  imageTag: string;
+  imageTag?: string;
+  tagPrefix?: string;
   codeBuildProjectName: string;
   sourceS3Url: string;
 };

--- a/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
+++ b/test/container-image-build.integ.snapshot/ContainerImageBuildIntegTest.template.json
@@ -431,7 +431,7 @@
        {
         "Ref": "BuildRepository4E6D17C2"
        },
-       ":0935d471547c278ca8652335f6d474db,push=true --provenance=false ."
+       ":<IMAGE_TAG>,push=true --provenance=false ."
       ]
      ]
     },
@@ -483,7 +483,6 @@
       ]
      ]
     },
-    "imageTag": "0935d471547c278ca8652335f6d474db",
     "codeBuildProjectName": {
      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2"
     },
@@ -526,6 +525,11 @@
      ]
     }
    },
+   "DependsOn": [
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd6491AAA9B2",
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicyBD233B55",
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30amd64RoleD95F32B9"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
@@ -605,7 +609,7 @@
    "Properties": {
     "Code": {
      "S3Bucket": {
-      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
      },
      "S3Key": {
       "Fn::Join": [
@@ -618,7 +622,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+             "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
             }
            ]
           }
@@ -631,7 +635,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+             "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
             }
            ]
           }
@@ -944,7 +948,7 @@
        {
         "Ref": "BuildRepository4E6D17C2"
        },
-       ":ca38901771f07ed68abee97d650d90e0,push=true,oci-mediatypes=true,compression=zstd,force-compression=true,compression-level=3 --provenance=false ."
+       ":<IMAGE_TAG>,push=true,oci-mediatypes=true,compression=zstd,force-compression=true,compression-level=3 --provenance=false ."
       ]
      ]
     },
@@ -996,7 +1000,6 @@
       ]
      ]
     },
-    "imageTag": "ca38901771f07ed68abee97d650d90e0",
     "codeBuildProjectName": {
      "Ref": "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549"
     },
@@ -1039,6 +1042,11 @@
      ]
     }
    },
+   "DependsOn": [
+    "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64C13E3549",
+    "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleDefaultPolicy2316728F",
+    "ContainerImageBuildArm64e83729feb1564e709bec452b15847a30amd64RoleC5F7BBFE"
+   ],
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
   },
@@ -1654,7 +1662,7 @@
        {
         "Ref": "BuildVpcRepositoryC4EB5D59"
        },
-       ":0935d471547c278ca8652335f6d474db,push=true --provenance=false ."
+       ":<IMAGE_TAG>,push=true --provenance=false ."
       ]
      ]
     },
@@ -1706,7 +1714,6 @@
       ]
      ]
     },
-    "imageTag": "0935d471547c278ca8652335f6d474db",
     "codeBuildProjectName": {
      "Ref": "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187"
     },
@@ -1750,6 +1757,11 @@
     }
    },
    "DependsOn": [
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64PolicyDocument194E3D91",
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64C6D1C187",
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64RoleDefaultPolicyF7E07B6C",
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64Role7FBDDED1",
+    "ContainerImageBuildAmd64e83729feb1564e709bec452b15847a30c8a085f75ccbc05f5149859bcf147b49eadd8ac37damd64SecurityGroup48FE16CC",
     "VpcV2IGWD1C41C9C",
     "VpcV2PrivateSubnet1DefaultRoute5D002E26",
     "VpcV2PrivateSubnet1RouteTable7476B1CF",
@@ -2155,17 +2167,17 @@
   }
  },
  "Parameters": {
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369": {
    "Type": "String",
-   "Description": "S3 bucket for asset \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "S3 bucket for asset \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9": {
    "Type": "String",
-   "Description": "S3 key for asset version \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "S3 key for asset version \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A": {
    "Type": "String",
-   "Description": "Artifact hash for asset \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "Artifact hash for asset \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
   "AssetParametersf7fa10e7cd7b9b27f49a4a335f4aa9795fb7e68a665c34ca8bf5711f0aa6aeabS3Bucket1FF22598": {
    "Type": "String",

--- a/test/container-image-build.integ.snapshot/asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/index.js
+++ b/test/container-image-build.integ.snapshot/asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/index.js
@@ -131,6 +131,8 @@ var handler = async (event, context) => {
           });
           break;
         case "ContainerImageBuild": {
+          const imageTag = props.imageTag ?? `${props.tagPrefix ?? ""}${newPhysicalId}`;
+          const buildCommand = props.buildCommand.replaceAll("<IMAGE_TAG>", imageTag);
           command = new import_client_codebuild.StartBuildCommand({
             projectName: props.codeBuildProjectName,
             environmentVariablesOverride: [
@@ -145,11 +147,11 @@ var handler = async (event, context) => {
               },
               {
                 name: "buildCommand",
-                value: props.buildCommand
+                value: buildCommand
               },
               {
                 name: "imageTag",
-                value: props.imageTag
+                value: imageTag
               },
               {
                 name: "projectName",

--- a/test/container-image-build.integ.snapshot/manifest.json
+++ b/test/container-image-build.integ.snapshot/manifest.json
@@ -19,13 +19,13 @@
           {
             "type": "aws:cdk:asset",
             "data": {
-              "path": "asset.aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-              "id": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
+              "path": "asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+              "id": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
               "packaging": "zip",
-              "sourceHash": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-              "s3BucketParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E",
-              "s3KeyParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57",
-              "artifactHashParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F"
+              "sourceHash": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+              "s3BucketParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369",
+              "s3KeyParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9",
+              "artifactHashParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A"
             }
           },
           {
@@ -197,22 +197,22 @@
             "data": "DeployTimeBuildCustomResourceHandlerdb740fd554364a848a09e6dfcd01f4f306AEFF37"
           }
         ],
-        "/ContainerImageBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3Bucket": [
+        "/ContainerImageBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3Bucket": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
           }
         ],
-        "/ContainerImageBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3VersionKey": [
+        "/ContainerImageBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3VersionKey": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
           }
         ],
-        "/ContainerImageBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/ArtifactHash": [
+        "/ContainerImageBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/ArtifactHash": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A"
           }
         ],
         "/ContainerImageBuildIntegTest/AssetParameters/f7fa10e7cd7b9b27f49a4a335f4aa9795fb7e68a665c34ca8bf5711f0aa6aeab/S3Bucket": [

--- a/test/container-image-build.integ.snapshot/tree.json
+++ b/test/container-image-build.integ.snapshot/tree.json
@@ -865,7 +865,7 @@
                   "aws:cdk:cloudformation:props": {
                     "code": {
                       "s3Bucket": {
-                        "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+                        "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
                       },
                       "s3Key": {
                         "Fn::Join": [
@@ -878,7 +878,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+                                      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
                                     }
                                   ]
                                 }
@@ -891,7 +891,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+                                      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
                                     }
                                   ]
                                 }
@@ -927,13 +927,13 @@
             "id": "AssetParameters",
             "path": "ContainerImageBuildIntegTest/AssetParameters",
             "children": {
-              "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d": {
-                "id": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-                "path": "ContainerImageBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
+              "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db": {
+                "id": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+                "path": "ContainerImageBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
                 "children": {
                   "S3Bucket": {
                     "id": "S3Bucket",
-                    "path": "ContainerImageBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3Bucket",
+                    "path": "ContainerImageBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3Bucket",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -941,7 +941,7 @@
                   },
                   "S3VersionKey": {
                     "id": "S3VersionKey",
-                    "path": "ContainerImageBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3VersionKey",
+                    "path": "ContainerImageBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3VersionKey",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -949,7 +949,7 @@
                   },
                   "ArtifactHash": {
                     "id": "ArtifactHash",
-                    "path": "ContainerImageBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/ArtifactHash",
+                    "path": "ContainerImageBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/ArtifactHash",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"

--- a/test/nodejs-build.integ.snapshot/NodejsBuildIntegTest.template.json
+++ b/test/nodejs-build.integ.snapshot/NodejsBuildIntegTest.template.json
@@ -445,7 +445,7 @@
    "Properties": {
     "Code": {
      "S3Bucket": {
-      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
      },
      "S3Key": {
       "Fn::Join": [
@@ -458,7 +458,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+             "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
             }
            ]
           }
@@ -471,7 +471,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+             "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
             }
            ]
           }
@@ -708,17 +708,17 @@
   }
  },
  "Parameters": {
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369": {
    "Type": "String",
-   "Description": "S3 bucket for asset \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "S3 bucket for asset \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9": {
    "Type": "String",
-   "Description": "S3 key for asset version \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "S3 key for asset version \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A": {
    "Type": "String",
-   "Description": "Artifact hash for asset \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "Artifact hash for asset \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
   "AssetParameters72f05c779a8bc73c6ec86f6eafc720508792e7526696d3ae45a7fddcfc473c9dS3Bucket7BF37945": {
    "Type": "String",

--- a/test/nodejs-build.integ.snapshot/asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/index.js
+++ b/test/nodejs-build.integ.snapshot/asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/index.js
@@ -131,6 +131,8 @@ var handler = async (event, context) => {
           });
           break;
         case "ContainerImageBuild": {
+          const imageTag = props.imageTag ?? `${props.tagPrefix ?? ""}${newPhysicalId}`;
+          const buildCommand = props.buildCommand.replaceAll("<IMAGE_TAG>", imageTag);
           command = new import_client_codebuild.StartBuildCommand({
             projectName: props.codeBuildProjectName,
             environmentVariablesOverride: [
@@ -145,11 +147,11 @@ var handler = async (event, context) => {
               },
               {
                 name: "buildCommand",
-                value: props.buildCommand
+                value: buildCommand
               },
               {
                 name: "imageTag",
-                value: props.imageTag
+                value: imageTag
               },
               {
                 name: "projectName",

--- a/test/nodejs-build.integ.snapshot/manifest.json
+++ b/test/nodejs-build.integ.snapshot/manifest.json
@@ -19,13 +19,13 @@
           {
             "type": "aws:cdk:asset",
             "data": {
-              "path": "asset.aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-              "id": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
+              "path": "asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+              "id": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
               "packaging": "zip",
-              "sourceHash": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-              "s3BucketParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E",
-              "s3KeyParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57",
-              "artifactHashParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F"
+              "sourceHash": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+              "s3BucketParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369",
+              "s3KeyParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9",
+              "artifactHashParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A"
             }
           },
           {
@@ -131,22 +131,22 @@
             "data": "NodejsBuildCustomResourceHandler25648b212c404f09aa65b6bbb0c446591C4101F8"
           }
         ],
-        "/NodejsBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3Bucket": [
+        "/NodejsBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3Bucket": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
           }
         ],
-        "/NodejsBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3VersionKey": [
+        "/NodejsBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3VersionKey": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
           }
         ],
-        "/NodejsBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/ArtifactHash": [
+        "/NodejsBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/ArtifactHash": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A"
           }
         ],
         "/NodejsBuildIntegTest/AssetParameters/72f05c779a8bc73c6ec86f6eafc720508792e7526696d3ae45a7fddcfc473c9d/S3Bucket": [

--- a/test/nodejs-build.integ.snapshot/tree.json
+++ b/test/nodejs-build.integ.snapshot/tree.json
@@ -640,7 +640,7 @@
                   "aws:cdk:cloudformation:props": {
                     "code": {
                       "s3Bucket": {
-                        "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+                        "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
                       },
                       "s3Key": {
                         "Fn::Join": [
@@ -653,7 +653,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+                                      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
                                     }
                                   ]
                                 }
@@ -666,7 +666,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+                                      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
                                     }
                                   ]
                                 }
@@ -702,13 +702,13 @@
             "id": "AssetParameters",
             "path": "NodejsBuildIntegTest/AssetParameters",
             "children": {
-              "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d": {
-                "id": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-                "path": "NodejsBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
+              "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db": {
+                "id": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+                "path": "NodejsBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
                 "children": {
                   "S3Bucket": {
                     "id": "S3Bucket",
-                    "path": "NodejsBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3Bucket",
+                    "path": "NodejsBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3Bucket",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -716,7 +716,7 @@
                   },
                   "S3VersionKey": {
                     "id": "S3VersionKey",
-                    "path": "NodejsBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3VersionKey",
+                    "path": "NodejsBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3VersionKey",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -724,7 +724,7 @@
                   },
                   "ArtifactHash": {
                     "id": "ArtifactHash",
-                    "path": "NodejsBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/ArtifactHash",
+                    "path": "NodejsBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/ArtifactHash",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"

--- a/test/soci-index-build.integ.snapshot/SociIndexBuildIntegTest.template.json
+++ b/test/soci-index-build.integ.snapshot/SociIndexBuildIntegTest.template.json
@@ -81,7 +81,7 @@
    "Properties": {
     "Code": {
      "S3Bucket": {
-      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
      },
      "S3Key": {
       "Fn::Join": [
@@ -94,7 +94,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+             "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
             }
            ]
           }
@@ -107,7 +107,7 @@
            "Fn::Split": [
             "||",
             {
-             "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+             "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
             }
            ]
           }
@@ -344,17 +344,17 @@
   }
  },
  "Parameters": {
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369": {
    "Type": "String",
-   "Description": "S3 bucket for asset \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "S3 bucket for asset \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9": {
    "Type": "String",
-   "Description": "S3 key for asset version \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "S3 key for asset version \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   },
-  "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F": {
+  "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A": {
    "Type": "String",
-   "Description": "Artifact hash for asset \"aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d\""
+   "Description": "Artifact hash for asset \"9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db\""
   }
  }
 }

--- a/test/soci-index-build.integ.snapshot/asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/index.js
+++ b/test/soci-index-build.integ.snapshot/asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/index.js
@@ -131,6 +131,8 @@ var handler = async (event, context) => {
           });
           break;
         case "ContainerImageBuild": {
+          const imageTag = props.imageTag ?? `${props.tagPrefix ?? ""}${newPhysicalId}`;
+          const buildCommand = props.buildCommand.replaceAll("<IMAGE_TAG>", imageTag);
           command = new import_client_codebuild.StartBuildCommand({
             projectName: props.codeBuildProjectName,
             environmentVariablesOverride: [
@@ -145,11 +147,11 @@ var handler = async (event, context) => {
               },
               {
                 name: "buildCommand",
-                value: props.buildCommand
+                value: buildCommand
               },
               {
                 name: "imageTag",
-                value: props.imageTag
+                value: imageTag
               },
               {
                 name: "projectName",

--- a/test/soci-index-build.integ.snapshot/manifest.json
+++ b/test/soci-index-build.integ.snapshot/manifest.json
@@ -33,13 +33,13 @@
           {
             "type": "aws:cdk:asset",
             "data": {
-              "path": "asset.aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-              "id": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
+              "path": "asset.9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+              "id": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
               "packaging": "zip",
-              "sourceHash": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-              "s3BucketParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E",
-              "s3KeyParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57",
-              "artifactHashParameter": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F"
+              "sourceHash": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+              "s3BucketParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369",
+              "s3KeyParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9",
+              "artifactHashParameter": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A"
             }
           },
           {
@@ -81,22 +81,22 @@
             "data": "DeployTimeBuildCustomResourceHandlerdb740fd554364a848a09e6dfcd01f4f306AEFF37"
           }
         ],
-        "/SociIndexBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3Bucket": [
+        "/SociIndexBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3Bucket": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
           }
         ],
-        "/SociIndexBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3VersionKey": [
+        "/SociIndexBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3VersionKey": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
           }
         ],
-        "/SociIndexBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/ArtifactHash": [
+        "/SociIndexBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/ArtifactHash": [
           {
             "type": "aws:cdk:logicalId",
-            "data": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dArtifactHashC99F560F"
+            "data": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbArtifactHashA955B34A"
           }
         ],
         "/SociIndexBuildIntegTest/SociIndexBuild024cf76a10034aa4aa4b12c32c09ca3camd64/Role/Resource": [

--- a/test/soci-index-build.integ.snapshot/tree.json
+++ b/test/soci-index-build.integ.snapshot/tree.json
@@ -227,7 +227,7 @@
                   "aws:cdk:cloudformation:props": {
                     "code": {
                       "s3Bucket": {
-                        "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3BucketA057BD7E"
+                        "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3Bucket7C24A369"
                       },
                       "s3Key": {
                         "Fn::Join": [
@@ -240,7 +240,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+                                      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
                                     }
                                   ]
                                 }
@@ -253,7 +253,7 @@
                                   "Fn::Split": [
                                     "||",
                                     {
-                                      "Ref": "AssetParametersaa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8dS3VersionKey4979DC57"
+                                      "Ref": "AssetParameters9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1dbS3VersionKeyD5434FC9"
                                     }
                                   ]
                                 }
@@ -289,13 +289,13 @@
             "id": "AssetParameters",
             "path": "SociIndexBuildIntegTest/AssetParameters",
             "children": {
-              "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d": {
-                "id": "aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
-                "path": "SociIndexBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d",
+              "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db": {
+                "id": "9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
+                "path": "SociIndexBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db",
                 "children": {
                   "S3Bucket": {
                     "id": "S3Bucket",
-                    "path": "SociIndexBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3Bucket",
+                    "path": "SociIndexBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3Bucket",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -303,7 +303,7 @@
                   },
                   "S3VersionKey": {
                     "id": "S3VersionKey",
-                    "path": "SociIndexBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/S3VersionKey",
+                    "path": "SociIndexBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/S3VersionKey",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"
@@ -311,7 +311,7 @@
                   },
                   "ArtifactHash": {
                     "id": "ArtifactHash",
-                    "path": "SociIndexBuildIntegTest/AssetParameters/aa47254059d94cff79a1f8a5a97c4e8a0e14a3f105d2b089464c0beeeb6cfe8d/ArtifactHash",
+                    "path": "SociIndexBuildIntegTest/AssetParameters/9b19c7d81a94bbc19fe2164453716f4d7f651b21f923c5c264fe80f5a939e1db/ArtifactHash",
                     "constructInfo": {
                       "fqn": "aws-cdk-lib.CfnParameter",
                       "version": "2.38.0"


### PR DESCRIPTION
https://github.com/tmokmss/deploy-time-build/pull/40 removed buildArgs from hash caluculation for image tag, but it sometimes prevents Lambda deployment does not occur unexpectedly because image tag kept even when the build artifact changed.