### PR TITLE
chore: use trusted publishing for npm and pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Install dependencies
         run: npm install
       - name: build
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
@@ -130,7 +130,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Install dependencies
         run: npm ci
       - name: release
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Download build artifacts
         uses: actions/download-artifact@v5
         with:
@@ -124,7 +124,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   release_pypi:
     name: Publish to PyPI
@@ -132,11 +132,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
@@ -164,6 +165,5 @@ jobs:
         run: mv .repo/dist dist
       - name: Release
         env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-pypi

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          node-version: "24"
       - name: Install dependencies
         run: npm ci
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -12,11 +12,14 @@ const project = new awscdk.AwsCdkConstructLibrary({
   name: 'deploy-time-build',
   license: 'MIT',
   repositoryUrl: 'https://github.com/tmokmss/deploy-time-build.git',
+  npmTrustedPublishing: true,
   publishToPypi: {
     distName: 'deploy-time-build',
     module: 'deploy_time_build',
+    trustedPublishing: true,
   },
   packageManager: NodePackageManager.NPM,
+  workflowNodeVersion: '24',
   eslintOptions: {
     dirs: [],
     ignorePatterns: ['example/**/*', 'lambda/**/*', 'test/assets/**/*', 'test/*.snapshot/**/*', '*.d.ts'],


### PR DESCRIPTION
To eliminate the use of long-term tokens.