### PR TITLE
feat: deprecate SociIndexBuild in favor of SociIndexV2Build

### DIFF
--- a/API.md
+++ b/API.md
@@ -362,7 +362,7 @@ new SociIndexBuild(scope: Construct, id: string, props: SociIndexBuildProps)
 
 ---
 
-##### `toString` <a name="toString" id="deploy-time-build.SociIndexBuild.toString"></a>
+##### ~~`toString`~~ <a name="toString" id="deploy-time-build.SociIndexBuild.toString"></a>
 
 ```typescript
 public toString(): string
@@ -379,7 +379,7 @@ Returns a string representation of this construct.
 
 ---
 
-##### `isConstruct` <a name="isConstruct" id="deploy-time-build.SociIndexBuild.isConstruct"></a>
+##### ~~`isConstruct`~~ <a name="isConstruct" id="deploy-time-build.SociIndexBuild.isConstruct"></a>
 
 ```typescript
 import { SociIndexBuild } from 'deploy-time-build'
@@ -411,7 +411,7 @@ Any object.
 
 ---
 
-##### `fromDockerImageAsset` <a name="fromDockerImageAsset" id="deploy-time-build.SociIndexBuild.fromDockerImageAsset"></a>
+##### ~~`fromDockerImageAsset`~~ <a name="fromDockerImageAsset" id="deploy-time-build.SociIndexBuild.fromDockerImageAsset"></a>
 
 ```typescript
 import { SociIndexBuild } from 'deploy-time-build'
@@ -447,7 +447,10 @@ A utility method to create a SociIndexBuild construct from a DockerImageAsset in
 
 ---
 
-##### `node`<sup>Required</sup> <a name="node" id="deploy-time-build.SociIndexBuild.property.node"></a>
+##### ~~`node`~~<sup>Required</sup> <a name="node" id="deploy-time-build.SociIndexBuild.property.node"></a>
+
+- *Deprecated:* Use {@link SociIndexV2Build } instead. Customers new to SOCI on AWS Fargate can only use SOCI index manifest v2.
+See [this article](https://aws.amazon.com/blogs/containers/improving-amazon-ecs-deployment-consistency-with-soci-index-manifest-v2/) for more details.
 
 ```typescript
 public readonly node: Node;

--- a/README.md
+++ b/README.md
@@ -153,27 +153,11 @@ new FargateTaskDefinition(this, 'TaskDefinition', {
 The third argument (props) are a superset of DockerImageAsset's properties. You can set a few additional properties such as `tag`, `repository`, and `zstdCompression`.
 
 ### Build SOCI index for a container image
-[Seekable OCI (SOCI)](https://aws.amazon.com/about-aws/whats-new/2022/09/introducing-seekable-oci-lazy-loading-container-images/) is a way to help start tasks faster for Amazon ECS tasks on Fargate 1.4.0. You can build and push a SOCI index using the `SociIndexBuild` or `SociIndexV2Build` construct.
+[Seekable OCI (SOCI)](https://aws.amazon.com/about-aws/whats-new/2022/09/introducing-seekable-oci-lazy-loading-container-images/) is a way to help start tasks faster for Amazon ECS tasks on Fargate 1.4.0. You can build and push a SOCI index using the `SociIndexV2Build` construct.
 
 ![soci-architecture](imgs/soci-architecture.png)
 
 The following code is an example to use the construct:
-
-```ts
-import { SociIndexBuild } from 'deploy-time-build';
-
-const asset = new DockerImageAsset(this, 'Image', { directory: 'example-image' });
-new SociIndexBuild(this, 'Index', { imageTag: asset.assetHash, repository: asset.repository });
-// or using a utility method
-SociIndexBuild.fromDockerImageAsset(this, 'Index2', asset);
-
-// Use the asset for ECS Fargate tasks
-import { AssetImage } from 'aws-cdk-lib/aws-ecs';
-const assetImage = AssetImage.fromDockerImageAsset(asset);
-```
-
-#### SOCI Index Manifest v2 Support
-You can also build [SOCI index with Manifest v2](https://github.com/awslabs/soci-snapshotter/blob/v0.10.0/docs/soci-index-manifest-v2.md) using the `SociIndexV2Build` construct:
 
 ```ts
 import { SociIndexV2Build } from 'deploy-time-build';
@@ -202,6 +186,9 @@ The `SociIndexV2Build` construct:
 - Uses the same ECR repository for input and output images
 
 We currently use [`soci-wrapper`](https://github.com/tmokmss/soci-wrapper) to build and push SOCI indices.
+
+> [!WARNING]
+> The previous `SocideIndexBuild` construct is now deprecated. Customers new to SOCI on AWS Fargate can only use SOCI index manifest v2. See [this article](https://aws.amazon.com/blogs/containers/improving-amazon-ecs-deployment-consistency-with-soci-index-manifest-v2/) for more details.
 
 #### Motivation - why do we need the `SociIndexBuild` construct?
 

--- a/src/soci-index-build.ts
+++ b/src/soci-index-build.ts
@@ -8,6 +8,7 @@ import { Code, Runtime, RuntimeFamily, SingletonFunction } from 'aws-cdk-lib/aws
 import { Construct } from 'constructs';
 import { SingletonProject } from './singleton-project';
 import { SociIndexBuildResourceProps } from './types';
+import { SociIndexV2Build } from './soci-index-v2-build';
 
 export interface SociIndexBuildProps {
   /**
@@ -27,6 +28,9 @@ export interface SociIndexBuildProps {
  * Build and publish a SOCI index for a container image.
  * A SOCI index helps start Fargate tasks faster in some cases.
  * Please read the following document for more details: https://docs.aws.amazon.com/AmazonECS/latest/userguide/container-considerations.html
+ *
+ * @deprecated Use {@link SociIndexV2Build} instead. Customers new to SOCI on AWS Fargate can only use SOCI index manifest v2.
+ * See [this article](https://aws.amazon.com/blogs/containers/improving-amazon-ecs-deployment-consistency-with-soci-index-manifest-v2/) for more details.
  */
 export class SociIndexBuild extends Construct {
   /**
@@ -113,7 +117,7 @@ curl -vv -i -X PUT -H 'Content-Type:' -d "@payload.json" "$responseURL"
       new PolicyStatement({
         actions: ['codebuild:StartBuild'],
         resources: [project.projectArn],
-      }),
+      })
     );
 
     props.repository.grantPullPush(project);


### PR DESCRIPTION
> Customers that have previously used SOCI on Fargate can continue to use the SOCI index manifest v1. However, we strongly advise customers migrate to v2. For these existing customers, Fargate lazy loads a container image attached to either a SOCI index manifest v1 or SOCI index manifest v2.

If CDK code using SociIndexBuild is deployed to a new AWS account, the lazy load never works. All the existing code should migrate to `SociIndexV2Build` asap.