### PR TITLE
feat(container-image-build): enable scanOnPush of the default ECR repository

### DIFF
--- a/src/nodejs-build.ts
+++ b/src/nodejs-build.ts
@@ -94,7 +94,7 @@ export class NodejsBuild extends Construct implements IGrantable {
     const handler = new SingletonFunction(this, 'CustomResourceHandler', {
       // Use raw string to avoid from tightening CDK version requirement
       runtime: new Runtime('nodejs22.x', RuntimeFamily.NODEJS),
-      code: Code.fromAsset(join(__dirname, '../lambda/trigger-codebuild/dist')),
+      code: Code.fromAsset(join(__dirname, '..', 'lambda', 'trigger-codebuild', 'dist')),
       handler: 'index.handler',
       uuid: '25648b21-2c40-4f09-aa65-b6bbb0c44659', // generated for this construct
       lambdaPurpose: 'NodejsBuildCustomResourceHandler',

--- a/src/soci-index-build.ts
+++ b/src/soci-index-build.ts
@@ -53,7 +53,7 @@ export class SociIndexBuild extends Construct {
     const handler = new SingletonFunction(this, 'CustomResourceHandler', {
       // Use raw string to avoid from tightening CDK version requirement
       runtime: new Runtime('nodejs22.x', RuntimeFamily.NODEJS),
-      code: Code.fromAsset(join(__dirname, '../lambda/trigger-codebuild/dist')),
+      code: Code.fromAsset(join(__dirname, '..', 'lambda', 'trigger-codebuild', 'dist')),
       handler: 'index.handler',
       uuid: 'db740fd5-5436-4a84-8a09-e6dfcd01f4f3', // generated for this construct
       lambdaPurpose: 'DeployTimeBuildCustomResourceHandler',

--- a/src/soci-index-v2-build.ts
+++ b/src/soci-index-v2-build.ts
@@ -61,7 +61,7 @@ export class SociIndexV2Build extends Construct {
     const handler = new SingletonFunction(this, 'CustomResourceHandler', {
       // Use raw string to avoid from tightening CDK version requirement
       runtime: new Runtime('nodejs22.x', RuntimeFamily.NODEJS),
-      code: Code.fromAsset(join(__dirname, '../lambda/trigger-codebuild/dist')),
+      code: Code.fromAsset(join(__dirname, '..', 'lambda', 'trigger-codebuild', 'dist')),
       handler: 'index.handler',
       uuid: 'db740fd5-5436-4a84-8a09-e6dfcd01f4f3', // generated for this construct
       lambdaPurpose: 'DeployTimeBuildCustomResourceHandler',
@@ -128,7 +128,7 @@ curl -i -X PUT -H 'Content-Type:' -d "@payload.json" "$responseURL"
       new PolicyStatement({
         actions: ['codebuild:StartBuild'],
         resources: [project.projectArn],
-      }),
+      })
     );
 
     props.repository.grantPullPush(project);

--- a/test/integ.container-image-build.js.snapshot/ContainerImageBuildIntegTest.assets.json
+++ b/test/integ.container-image-build.js.snapshot/ContainerImageBuildIntegTest.assets.json
@@ -43,16 +43,16 @@
         }
       }
     },
-    "16d150644872ea88464ea8f88cee4092306cd22327ecb92864797e18c711a96f": {
+    "77807388cb9565a638520f4f29ffad683dc734aa115bbd7f4459055e84d0d746": {
       "displayName": "ContainerImageBuildIntegTest Template",
       "source": {
         "path": "ContainerImageBuildIntegTest.template.json",
         "packaging": "file"
       },
       "destinations": {
-        "current_account-current_region-18271ba7": {
+        "current_account-current_region-723e0682": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "16d150644872ea88464ea8f88cee4092306cd22327ecb92864797e18c711a96f.json",
+          "objectKey": "77807388cb9565a638520f4f29ffad683dc734aa115bbd7f4459055e84d0d746.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ.container-image-build.js.snapshot/ContainerImageBuildIntegTest.template.json
+++ b/test/integ.container-image-build.js.snapshot/ContainerImageBuildIntegTest.template.json
@@ -475,6 +475,9 @@
    "Type": "AWS::ECR::Repository",
    "Properties": {
     "EmptyOnDelete": true,
+    "ImageScanningConfiguration": {
+     "ScanOnPush": true
+    },
     "RepositoryPolicyText": {
      "Statement": [
       {
@@ -1562,7 +1565,10 @@
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete",
    "Properties": {
-    "EmptyOnDelete": true
+    "EmptyOnDelete": true,
+    "ImageScanningConfiguration": {
+     "ScanOnPush": true
+    }
    }
   },
   "BuildVpc1895B133": {

--- a/test/integ.container-image-build.js.snapshot/manifest.json
+++ b/test/integ.container-image-build.js.snapshot/manifest.json
@@ -18,7 +18,7 @@
         "validateOnSynth": false,
         "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
         "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
-        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/16d150644872ea88464ea8f88cee4092306cd22327ecb92864797e18c711a96f.json",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/77807388cb9565a638520f4f29ffad683dc734aa115bbd7f4459055e84d0d746.json",
         "requiresBootstrapStackVersion": 6,
         "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
         "additionalDependencies": [


### PR DESCRIPTION
We enable [ScanOnPush](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ecr-repository.html#cfn-ecr-repository-imagescanningconfiguration) property of the default repository that is automatically created.